### PR TITLE
Pull request for graph/SynchronizedDynamicGraph.scala

### DIFF
--- a/src/main/scala/com/twitter/cassovary/graph/SynchronizedDynamicGraph.scala
+++ b/src/main/scala/com/twitter/cassovary/graph/SynchronizedDynamicGraph.scala
@@ -20,8 +20,7 @@ import StoredGraphDir._
  * A class support dynamically adds new nodes and dynamically add/delete edges in existing nodes.
  * It currently doesn't support delete nodes
  */
-class SynchronizedDynamicGraph(val graphDir: StoredGraphDir)
+class SynchronizedDynamicGraph(val graphDir: StoredGraphDir = BothInOut)
     extends DynamicDirectedGraphHashMap(graphDir) {
-  def this() = this(BothInOut)
-  def nodeFactory(id: Int) = new SynchronizedDynamicNode(id)
+  override def nodeFactory(id: Int) = new SynchronizedDynamicNode(id)
 }


### PR DESCRIPTION
Pull request (minor) for graph/SynchronizedDynamicGraph.scala, changed constructor to use default value instead of specifying a single auxiliary constructor, and made nodeFactory function override explicit - when the override was unstated it confused me for a bit when I was working with it.

Passes all tests packaged with Cassovary.
