### PR TITLE
Compliation fixes for examples

### DIFF
--- a/examples/scala/build_run_example.sh
+++ b/examples/scala/build_run_example.sh
@@ -33,7 +33,7 @@ fi
 
 JAVA_CP=(
   $(find $root/target -name 'cassovary*.jar') \
-  $(ls -t $HOME/.sbt/boot/scala-*/lib/scala-library.jar | head -1) \
+  $(ls -t -1 $HOME/.sbt/boot/scala-*/lib/scala-library.jar | head -1) \
   $(find $root/lib_managed/jars/ -name '*.jar')
 )
 JAVA_CP=$(echo ${JAVA_CP[@]} | tr ' ' ':')


### PR DESCRIPTION
Run local `sbt` even when "." is not in user's PATH, and remove hardcoding of scala-2.8.1 scala-library.jar path.

Tested on both OSX and RHEL6 by running:
./sbt update && ./sbt test && ./sbt package && examples/scala/build_run_example.sh
