### PR TITLE
Resolving issue #51 - Fix warnings from scala 2.10 compilation

### DIFF
--- a/src/main/scala/com/twitter/cassovary/graph/GraphDir.scala
+++ b/src/main/scala/com/twitter/cassovary/graph/GraphDir.scala
@@ -16,7 +16,7 @@ package com.twitter.cassovary.graph
 /**
  * A representation of the two directions edges point in a directed graph.
  */
-object GraphDir extends Enumeration(0, "OutDir", "InDir") {
+object GraphDir extends Enumeration {
   type GraphDir = Value
 
   /**

--- a/src/main/scala/com/twitter/cassovary/graph/Traverser.scala
+++ b/src/main/scala/com/twitter/cassovary/graph/Traverser.scala
@@ -37,8 +37,9 @@ trait Traverser extends Iterator[Node] { self =>
 /**
  * Bounds an iterator to go no more than a specified maximum number of steps
  */
-trait BoundedIterator[T] extends {  private var numStepsTaken = 0L } with Iterator[T] {
+trait BoundedIterator[T] extends Iterator[T] {
   val maxSteps: Long
+  private var numStepsTaken = 0L
 
   abstract override def next = {
     numStepsTaken += 1

--- a/src/main/scala/com/twitter/cassovary/graph/bipartite/BipartiteGraph.scala
+++ b/src/main/scala/com/twitter/cassovary/graph/bipartite/BipartiteGraph.scala
@@ -128,7 +128,7 @@ class BipartiteGraph(val leftNodes: Array[BipartiteNode], val leftNodeCount: Int
   val storedGraphDir =  StoredGraphDir.Bipartite
 
   /**
-   * Checks for a given ndoe, is a graph direction is stored.
+   * Checks for a given node, is a graph direction is stored.
    * e.g., if the node being queries is a left node, and the asked for direction is OutDir,
    * then if the graph's stored direction is LeftToRight or Both, then this function returns true,
    * false otherwise.
@@ -141,6 +141,7 @@ class BipartiteGraph(val leftNodes: Array[BipartiteNode], val leftNodeCount: Int
         case (true, GraphDir.OutDir) => bipartiteGraphDir == BipartiteGraphDir.LeftToRight
         case (false, GraphDir.InDir) => bipartiteGraphDir == BipartiteGraphDir.LeftToRight
         case (false, GraphDir.OutDir) => bipartiteGraphDir == BipartiteGraphDir.RightToLeft
+        case (_, _) => false
       }
     }
   }

--- a/src/test/scala/com/twitter/cassovary/graph/GraphUtilsSpec.scala
+++ b/src/test/scala/com/twitter/cassovary/graph/GraphUtilsSpec.scala
@@ -16,6 +16,7 @@ package com.twitter.cassovary.graph
 import com.twitter.cassovary.graph.GraphDir._
 import com.twitter.cassovary.graph.util.FastUtilConversion
 import com.twitter.util.Duration
+import com.twitter.util.Stopwatch
 import it.unimi.dsi.fastutil.ints.Int2IntMap
 import it.unimi.dsi.fastutil.objects.Object2IntMap
 import org.specs.Specification
@@ -194,10 +195,9 @@ class GraphUtilsSpec extends Specification {
       val walkParams = GraphUtils.RandomWalkParams(numWalkSteps, resetProb, None,
         Some(numWalkSteps.toInt), None, false, GraphDir.OutDir, false)
       (1 to (numTimes + ignoreFirstNum)) foreach { times =>
-        val (walk, duration) = Duration.inMilliseconds {
-          graphUtils.randomWalk(OutDir, Seq(startNodeId), walkParams)
-        }
-
+        val elapsed: () => Duration = Stopwatch.start()
+        val walk = graphUtils.randomWalk(OutDir, Seq(startNodeId), walkParams)
+        val duration: Duration = elapsed()
         val (visitsCounter, pathsCounterOption) = walk
         visitsCounter.infoAllNodes.size must be_> (graph.getNodeById(startNodeId).get.outboundCount)
         if (times > ignoreFirstNum) {


### PR DESCRIPTION
Fixing the following warning (by using scala.reflect.ClassTag) gives compilation error with scala 2.9.3 

[warn] .../cassovary/src/main/scala/com/twitter/cassovary/util/SmallBoundedPriorityQueue.scala:22: type ClassManifest in package reflect is deprecated: Use scala.reflect.ClassTag instead
[warn] class SmallBoundedPriorityQueue[A](maxSize: Int)(implicit m: ClassManifest[A], ord: Ordering[A]) {
[warn] one warning found

I have not included the changes related to above warning in this PR...
Should the change(s) be made?
