### PR TITLE
Ajeet/graph2

### DIFF
--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph2/Graph2.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph2/Graph2.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.twitter.cassovary.graph2
+
+import com.twitter.util.{Await, Future}
+
+/**
+ * This is an alternative base trait for a graph. It allows you to keep
+ * distinct information about the source nodes, destination nodes and the edges
+ *
+ * Please consider this experimental and subject to change.
+ *
+ * Here are the properties
+ * - The trait implements an adjacency representation from source nodes to
+ *   destination nodes
+ * - Given a destination node, we need not have the incoming nodes
+ * - All nodes are indexed by a long id
+ * - All source nodes have a unique id
+ * - All destination nodes have a unique id
+ * - The sets of source node ids and destination node ids are not necessarily
+ *   disjoint
+ * - We cannot determine the incoming edges for a node V directly. If this is
+ *   needed, it can be arranged by additionally maintaining the transpose of
+ *   this graph
+ *
+ * The default implementations for some of the methods may be inefficient.
+ *
+ * @tparam U the type of the source nodes
+ * @tparam V the type of the destination nodes
+ * @tparam E the type of the edge
+ */
+trait Graph2[+U, +V, +E] {
+  /**
+   * @param u source node id
+   * @returns the source node object, given its index
+   */
+  def sourceNode(u: Long): Future[Option[U]]
+
+  /**
+   * @param v destination node id
+   * @returns the destination node object, given its index
+   */
+  def destinationNode(v: Long): Future[Option[V]]
+
+  /**
+   * Returns the destination node ids and the edge object corresponding to each edge
+   * @param u source node id
+   * @returns outbound edge objects, and the destination ids
+   */
+  def edges(u: Long): Future[Option[Seq[(Long, E)]]]
+
+  /**
+   * Returns the destination node ids for a given source id
+   * @param u source node id
+   * @returns node ids of the neighbors of the input node
+   */
+  def neighbors(u: Long): Future[Option[Seq[Long]]] = edges(u) map { _ map { _ map { case (id, _) => id } } }
+}
+
+/**
+ * This is a simpler version of Graph2, where there is no notion of edge or node types
+ */
+trait SimpleGraph2 extends Graph2[Long, Long, Unit] {
+  def sourceNode(u: Long): Future[Option[Long]] = Future.value(Some(u))
+  def destinationNode(v: Long): Future[Option[Long]] = Future.value(Some(v))
+  def edges(u: Long): Future[Option[Seq[(Long, Unit)]]] = neighbors(u) map { _ map { _ map { id => (id, ()) } } }
+}

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph2/SimpleMappedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph2/SimpleMappedGraph.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.twitter.cassovary.graph2
+
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import com.twitter.cassovary.util.{ByteBufferBackedLongSeq, ConstantDB}
+import com.twitter.util.Future
+
+/**
+ * Graph based on an underlying ConstantDB backed key-value store. The keys are
+ * of type Long and values are of type Seq[Long]
+ */
+class SimpleMappedGraph(
+  graphDir: String
+) extends SimpleGraph2 {
+  import SimpleMappedGraph._
+
+  val cdb = new ConstantDB(graphDir, keySerializer _, keyDeserializer _, valueDeserializer _)
+
+  override def neighbors(u: Long): Future[Option[Seq[Long]]] = Future.value(cdb(u))
+}
+
+object SimpleMappedGraph {
+  private def keySerializer(k: Long) = {
+    val bb = ByteBuffer.allocate(8) 
+    bb.putLong(k)
+    bb.flip()
+    bb
+  }
+
+  private def keyDeserializer(bb: ByteBuffer) = bb.getLong()
+
+  private def valueDeserializer(bb: ByteBuffer) = new ByteBufferBackedLongSeq(bb)
+
+  private def valueSerializer(vs: Seq[Long]) = {
+    val bb = ByteBuffer.allocate(vs.size * 8)
+    vs foreach { v => bb.putLong(v) }
+    bb.flip()
+    bb
+  }
+
+  def collectEdges[T](input: Stream[(T, T)]): Stream[(T, Seq[T])] = {
+    if (input.isEmpty) {
+      Stream.empty
+    } else {
+      val (source, dest) = input.head
+      val xs = input.tail
+      val (sibs, rest) = xs span { case (s, _) => s == source }
+      (source, (dest +: (sibs map { case (_, d) => d } )).toList) #:: collectEdges(rest)
+    }
+  }
+
+  def write(folder: String, input: Stream[(Long, Seq[Long])]) {
+    val binaryData = input map { case (k, v) => (keySerializer(k), valueSerializer(v)) }
+    ConstantDB.write(folder, binaryData)
+  }
+}
+

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/util/ByteBufferBackedLongSeq.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/util/ByteBufferBackedLongSeq.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.twitter.cassovary.util
+
+import java.nio.ByteBuffer
+
+class ByteBufferBackedLongSeq(bb: ByteBuffer) extends IndexedSeq[Long] {
+  private[this] val lb = bb.asLongBuffer
+
+  val length = lb.remaining()
+
+  def apply(id: Int): Long = {
+    if (id < 0 || id > length) throw new IndexOutOfBoundsException
+    val l = lb.duplicate()
+    l.position(id)
+    l.get()
+  }
+}

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/util/ConstantDB.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/util/ConstantDB.scala
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2014 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.twitter.cassovary.util
+
+import com.google.common.primitives.UnsignedBytes
+import java.io.{FileOutputStream, RandomAccessFile}
+import java.nio.channels.FileChannel
+import java.nio.channels.FileChannel.{MapMode => Mode}
+import java.nio.file.{Files, Paths}
+import java.nio.{ByteBuffer, MappedByteBuffer}
+import java.util.Arrays
+import scala.collection.mutable.ListBuffer
+
+/**
+ * Constant database implementation inspired by http://cr.yp.to/cdb.html.
+ * Unlike cdb, there is no limit on the total database size.  A single entry
+ * must be smaller than 2GB. Additionally, when creating the database the input
+ * keys must be provided in sorted order
+ *
+ * The database is stored under a dedicated folder. It consists of one
+ * index.bin file, and multiple data files. The ith data file is named
+ * part<i>.bin
+ *
+ * JVM does not allow you to memory map a file greater than 2GB. This is set as
+ * the max part file size by default
+ *
+ * The index file has the following format.
+ * -----------------------------------------------------------------
+ * | part0 key size | part0 key | ... | partn key size | partn key |
+ * -----------------------------------------------------------------
+ * 
+ * The key stored in the index file is the least key in that part. To lookup
+ * the value of a key, first the part is selected by consulting the index, then
+ * we lookup the key in the part
+ *
+ * The part files are stored as described in http://cr.yp.to/cdb/cdb.txt
+ */
+class ConstantDB[K, V](
+  dir: String,
+  keySerializer: K => ByteBuffer,
+  keyDeserializer: ByteBuffer => K,
+  valueDeserializer: ByteBuffer => V
+)(
+  implicit ord: Ordering[K]
+) {
+  import ConstantDB._
+
+  def apply(key: K): Option[V] = {
+    lookup(keySerializer(key)) map { valueDeserializer(_) }
+  }
+
+  private val index: IndexedSeq[K] = {
+    val path = Paths.get("%s/index.bin".format(dir))
+    val bb = ByteBuffer.wrap(Files.readAllBytes(path))
+    var partIdx: ListBuffer[K] = ListBuffer.empty
+    while (bb.position() < bb.limit()) {
+      if (bb.limit() - bb.position() < 4) throw new Exception("Invalid index file")
+      val sz = bb.getInt()
+      val keybb = bb.duplicate()
+      keybb.position(bb.position())
+      keybb.limit(bb.position() + sz)
+      bb.position(bb.position() + sz)
+      partIdx.append(keyDeserializer(keybb))
+    }
+    partIdx.toIndexedSeq
+  }
+
+  val numParts = index.size
+
+  private val bufs: Array[MappedByteBuffer] = {
+    (0 until numParts).toArray map { i =>
+      val file = new RandomAccessFile("%s/part%s.bin".format(dir, i), "r")
+      file.getChannel().map(Mode.READ_ONLY, 0, file.length())
+    }
+  }
+
+
+  private def getBuf(input: ByteBuffer): Option[MappedByteBuffer] = {
+    val k = keyDeserializer(input.duplicate())
+    val idx = index.lastIndexWhere(currK => ord.lteq(currK, k))
+    if (idx == -1) {
+      Some(bufs.last)
+    } else {
+      Some(bufs(idx))
+    }
+  }
+
+  private def lookup(input: ByteBuffer): Option[ByteBuffer] = {
+    getBuf(input.duplicate()) flatMap { bb =>
+      val h = hash(input.duplicate())
+      val hashPtrIdx = (h % 256) * (4+4)
+      val hashOffset = bb.getInt(hashPtrIdx)
+      val numSlots = bb.getInt(hashPtrIdx + 4)
+
+      if (numSlots == 0) {
+        None
+      } else {
+        val start = (h >> 8) % numSlots
+        (0 until numSlots).view
+          .map { i => 
+            val rotatedIdx = (i + start) % numSlots
+            val currHashPtr = hashOffset + (rotatedIdx * 8)
+            (bb.getInt(currHashPtr), bb.getInt(currHashPtr + 4)) match {
+              case (h1, p1) if p1 == 0 || h1 == 0 =>
+                (None, false)
+              case (h1, p1) if h1 == h =>
+                val keyLength = bb.getInt(p1)
+                val valLength = bb.getInt(p1+4)
+                input.mark()
+                if (keyLength != input.remaining() || !((0 until keyLength) forall { i => bb.get(p1+8+i) == input.get() })) {
+                  input.reset()
+                  (None, true)
+                } else {
+                  val sliced = bb.slice()
+                  val valStart = p1+8+keyLength
+                  sliced.position(valStart)
+                  sliced.limit(valStart + valLength)
+                  (Some(sliced), false)
+                }
+              case _ => (None, true)
+            }
+          }
+          .collectFirst { case (res, false) => res }
+          .getOrElse(None)
+      }
+    }
+  }
+}
+
+object ConstantDB {
+  private val headerSize = (4+4)*256
+
+  private def intToByteBuffer(i: Int) = {
+    val bb = ByteBuffer.allocate(4)
+    bb.putInt(i)
+    bb.flip()
+    bb
+  }
+
+  private def hash(key: ByteBuffer, initial: Long = 5381): Int = {
+    var h = initial
+    while (key.position() < key.limit()) {
+      h = (((h << 5) + h) ^ key.get()) & 0xffffffffL
+    }
+    math.abs(h.toInt)
+  }
+
+  private def getFileChannel(
+    folder: String,
+    part: Int
+  ) = {
+    (new FileOutputStream("%s/part%s.bin".format(folder, part))).getChannel()
+  }
+
+
+  def write(
+    folder: String,
+    data: Stream[(ByteBuffer, ByteBuffer)],
+    maxSize: Int = Int.MaxValue
+  ) {
+    if (data.nonEmpty) {
+      val (key, _) = data.head
+      val part = 0
+      doWrite(folder, part, getFileChannel(folder, part), headerSize, headerSize, Map.empty, data, Seq(key), None, maxSize, 0)
+    }
+  }
+
+  private def doWrite(
+    folder: String,
+    part: Int,
+    fileChannel: FileChannel,
+    sizeSoFar: Int,
+    pos: Int,
+    buckets: Map[Int, Seq[(Int, Int)]],
+    data: Stream[(ByteBuffer, ByteBuffer)],
+    partIndex: Seq[ByteBuffer],
+    last: Option[ByteBuffer],
+    maxSize: Int = Int.MaxValue,
+    numWritten: Int = 0
+  ) {
+    def writeHashesAndHeader {
+      (0 until 256) map { id =>
+        val hashes = buckets.getOrElse(id, Nil)
+        val ncells = hashes.size * 2
+        val cells = (0 until ncells) .map { _ => (0, 0) }.toArray
+        hashes foreach { case (h, p) =>
+          var idx = (h >> 8) % ncells
+          while (cells(idx)._1 != 0) {
+            idx = (idx + 1) % ncells
+          }
+          cells(idx) = (h, p)
+        }
+        cells foreach { case (h, p) =>
+          fileChannel.write(intToByteBuffer(h))
+          fileChannel.write(intToByteBuffer(p))
+        }
+      }
+      fileChannel.position(0)
+      var posHash = pos
+      (0 until 256) map { id =>
+        val hashes = buckets.getOrElse(id, Nil)
+        fileChannel.write(intToByteBuffer(posHash))
+        fileChannel.write(intToByteBuffer(hashes.size * 2))
+        posHash += (hashes.size * 2) * (4 + 4)
+      }
+      fileChannel.close()
+    }
+
+    data match {
+      case Stream.Empty => {
+        writeHashesAndHeader
+        val fos = new FileOutputStream("%s/index.bin".format(folder)).getChannel()
+        try {
+          partIndex foreach { key: ByteBuffer =>
+            fos.write(intToByteBuffer(key.remaining()))
+            fos.write(key)
+          }
+        } finally {
+          fos.close()
+        }
+      }
+
+      case (key, value) #:: rest => {
+        val incr = key.remaining() + value.remaining() + 24
+        val newSize = sizeSoFar + incr
+        if (newSize <= maxSize) {
+          fileChannel.position(pos)
+          fileChannel.write(intToByteBuffer(key.remaining()))
+          fileChannel.write(intToByteBuffer(value.remaining()))
+          fileChannel.write(key.duplicate())
+          fileChannel.write(value)
+          val h = hash(key.duplicate())
+          val hashBucket = h % 256
+          val newBuckets = buckets + (hashBucket -> (buckets.getOrElse(hashBucket, Nil) :+ (h, pos)))
+          doWrite(folder, part, fileChannel, newSize, fileChannel.position().toInt, newBuckets, rest, partIndex, Some(key), maxSize, numWritten + 1)
+        } else {
+          writeHashesAndHeader
+          if (numWritten == 0) throw new Exception("A single record is larger than allowed max size")
+          doWrite(folder, part+1, getFileChannel(folder, part+1), headerSize, headerSize, Map.empty, data, partIndex :+ key, None, maxSize, 0)
+        }
+      }
+    }
+  }
+}

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph2/SimpleMappedGraphSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph2/SimpleMappedGraphSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.twitter.cassovary.graph2
+
+import org.specs.Specification
+import java.nio.file.Files
+import scala.util.Random
+
+class SimpleMappedGraphSpec extends Specification {
+  val unsortedEdgeMap: Map[Long, Seq[Long]] = (0 until 1000) .map { _ =>
+    Random.nextLong() -> ((0 until 10) map { _ => Random.nextLong() })
+  }.toMap
+
+  val edges = unsortedEdgeMap.toSeq.sortBy(_._1)
+
+  val tempDir = Files.createTempDirectory("cassovary").toString
+  SimpleMappedGraph.write(tempDir, edges.toStream)
+  val graph = new SimpleMappedGraph(tempDir)
+
+  "A SimpleMappedGraph" should {
+    "group the input stream of edges correctly" in {
+      val input = Seq((1, 1), (2, 3), (2, 4)).toStream
+      SimpleMappedGraph.collectEdges(input).toList mustEqual List((1, Seq(1)), (2, Seq(3, 4)))
+      val input2 = Seq((1, 1), (2, 3), (3, 4)).toStream
+      SimpleMappedGraph.collectEdges(input2).toList mustEqual List((1, Seq(1)), (2, Seq(3)), (3, Seq(4)))
+    }
+
+    "Retrieve edges correctly" in {
+      println(tempDir)
+      edges map { case (k: Long, v: Seq[Long]) =>
+        graph.neighbors(k).get mustEqual Some(v)
+      }
+      (0 until 1000) map { _ =>
+        val n = Random.nextLong()
+        graph.neighbors(n).get mustEqual unsortedEdgeMap.get(n)
+      }
+    }
+  }
+}

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/util/ByteBufferBackedLongSeqSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/util/ByteBufferBackedLongSeqSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.twitter.cassovary.util
+
+import java.nio.ByteBuffer
+import org.specs.Specification
+
+class ByteBufferBackedLongSeqSpec extends Specification {
+
+  def bbForList(ll: Seq[Long]): ByteBuffer = {
+    val bb = ByteBuffer.allocate(ll.size * 8)
+    ll foreach { l => bb.putLong(l) }
+    bb.flip()
+    bb
+  }
+
+  "A ByteBufferBackedLongSeq" should {
+    "Get the same list back" in {
+      val testSeq = Seq(12L, 3L, 5L, 56L)
+      val bb = bbForList(testSeq)
+      new ByteBufferBackedLongSeq(bb) mustEqual testSeq
+    }
+  }
+}

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/util/ConstantDBSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/util/ConstantDBSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.twitter.cassovary.util
+
+import org.specs.Specification
+import java.nio.file.Files
+import java.nio.ByteBuffer
+
+class ConstantDBSpec extends Specification {
+  val edges = Seq(
+    "a" -> "abc",
+    "bdg" -> "efg"
+  )
+
+  val tempDir = Files.createTempDirectory("cassovary").toString
+
+  ConstantDB.write(
+    tempDir,
+    edges.toStream map { case (k, v) =>
+      ByteBuffer.wrap(k.getBytes) -> ByteBuffer.wrap(v.getBytes)
+    },
+    2080
+    )
+
+  val cdb = new ConstantDB(
+    tempDir,
+    (x: String) => ByteBuffer.wrap(x.getBytes),
+    (x: ByteBuffer) =>{
+      val b = new Array[Byte](x.remaining())
+      x.get(b)
+      new String(b)
+    },
+    (x: ByteBuffer) => {
+      val b = new Array[Byte](x.remaining())
+      x.get(b)
+      new String(b)
+    }
+    )
+
+  "A ConstantDB" should {
+    "number of parts should be correct" in {
+      cdb.numParts mustEqual 2
+    }
+
+    "retrive data correctly" in {
+      cdb("a") mustEqual Some("abc")
+      cdb("bdg") mustEqual Some("efg")
+      cdb("0") mustEqual None
+      cdb("asdf") mustEqual None
+      cdb("z") mustEqual None
+    }
+
+    "throw exception if it finds an item which cannot fit into a single file" in {
+      val tempDir2 = Files.createTempDirectory("cassovary").toString
+
+      ConstantDB.write(
+        tempDir2,
+        edges.toStream map { case (k, v) =>
+          ByteBuffer.wrap(k.getBytes) -> ByteBuffer.wrap(v.getBytes)
+        },
+        2076
+      ) must throwA[Exception]
+    }
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,29 +5,35 @@ import SonatypeKeys._
 
 
 object Cassovary extends Build {
+  val twitterUtilVersion = "6.12.1"
 
   val sharedSettings = Seq(
     version := "3.3.0",
     organization := "com.twitter",
     scalaVersion := "2.9.3",
     retrieveManaged := true,
-    crossScalaVersions := Seq("2.9.3","2.10.3"),
+    crossScalaVersions := Seq("2.9.1","2.10.3"),
     libraryDependencies ++= Seq(
       "com.google.guava" % "guava" % "11.0.2",
-      "it.unimi.dsi" % "fastutil" % "6.4.4" % "provided",
+      "it.unimi.dsi" % "fastutil" % "6.4.4",
       "org.mockito" % "mockito-all" % "1.8.5" % "test",
       "com.twitter" %% "ostrich" % "9.1.0" cross CrossVersion.binaryMapped {
-        case "2.9.3" => "2.9.2"
+        case x if x startsWith "2.9" => "2.9.2"
         case x if x startsWith "2.10" => "2.10"
         case x => x
       },
-      "com.twitter" %% "util-logging" % "6.12.1" cross CrossVersion.binaryMapped {
-        case "2.9.3" => "2.9.2"
+      "com.twitter" %% "util-core" % twitterUtilVersion cross CrossVersion.binaryMapped {
+        case x if x startsWith "2.9" => "2.9.2"
+        case x if x startsWith "2.10" => "2.10"
+        case x => x
+      },
+      "com.twitter" %% "util-logging" % twitterUtilVersion cross CrossVersion.binaryMapped {
+        case x if x startsWith "2.9" => "2.9.2"
         case x if x startsWith "2.10" => "2.10"
         case x => x
       },
       "org.scala-tools.testing" %% "specs" % "1.6.9" % "test" cross CrossVersion.binaryMapped {
-        case "2.9.3" => "2.9.1"
+        case x if x startsWith "2.9" => "2.9.1"
         case x if x startsWith "2.10" => "2.10"
         case x => x
       },
@@ -39,8 +45,8 @@ object Cassovary extends Build {
     scalacOptions ++= Seq("-encoding", "utf8"),
     scalacOptions += "-deprecation",
 
-    javacOptions ++= Seq("-source", "1.6", "-target", "1.6"),
-    javacOptions in doc := Seq("-source", "1.6"),
+    javacOptions ++= Seq("-source", "1.7", "-target", "1.7"),
+    javacOptions in doc := Seq("-source", "1.7"),
 
     // Sonatype publishing
     publishArtifact in Test := false,

--- a/sbt
+++ b/sbt
@@ -6,7 +6,7 @@ root=$(
 )
 
 sbtjar=sbt-launch.jar
-sbtver=0.13.1
+sbtver=0.13.2
 
 if [ ! -f $sbtjar ]; then
   echo "downloading $sbtjar" 1>&2
@@ -15,7 +15,7 @@ fi
 
 test -f $sbtjar || exit 1
 sbtjar_md5=$(openssl md5 < $sbtjar|cut -f2 -d'='|awk '{print $1}')
-if [ "${sbtjar_md5}" != 79e367c11fc2294f865c6ecc47b8886c ]; then
+if [ "${sbtjar_md5}" != 3bc22e5885fa0792ff500a8e91d0936d ]; then
   echo 'bad sbtjar!' 1>&2
   exit 1
 fi
@@ -23,7 +23,9 @@ fi
 
 test -f ~/.sbtconfig && . ~/.sbtconfig
 
-java -ea                          \
+# Removing -ea here because of https://groups.google.com/forum/#!topic/scala-language/FJi8n2dfD3k
+# Running into this issue with FileChannel.MapMode
+java                              \
   $SBT_OPTS                       \
   $JAVA_OPTS                      \
   -Djava.net.preferIPv4Stack=true \


### PR DESCRIPTION
```
Graph2, ConstantDB and SimpleMappedGraph

Graph2 is a new base interface for a graph. It lets the neighbors be
fetched over a network, by wrapping them in a future. In addition, the
underlying node ids are now longs.

ConstantDB is a port of D. J. Bernstein's excellent cdb package
(http://cr.yp.to/cdb.html), with a few changes. Unlike cdb, there is
no limit on the total database size.  A single entry must be smaller
than 2GB. Additionally, when creating the database the input keys must
be provided in sorted order.

SimpleMappedGraph is a graph implementation that sits on top of
ConstantDB and implements Graph2.
```
