### PR TITLE
Improved traversers

### DIFF
--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/TestGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/TestGraph.scala
@@ -67,6 +67,14 @@ object TestGraphs {
     NodeIdEdgesMaxId(12, Array(11))
     ).iterator, StoredGraphDir.BothInOut)
 
+  def g5 = ArrayBasedDirectedGraph( ()  => Seq(
+    NodeIdEdgesMaxId(10, Array(11, 12, 13)),
+    NodeIdEdgesMaxId(11, Array(12)),
+    NodeIdEdgesMaxId(12, Array(11)),
+    NodeIdEdgesMaxId(13, Array(14)),
+    NodeIdEdgesMaxId(14, Array())
+    ).iterator, StoredGraphDir.BothInOut)
+
   val nodeSeqIterator = () => Seq(
       NodeIdEdgesMaxId(10, Array(11, 12, 13)),
       NodeIdEdgesMaxId(11, Array(12, 14)),

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/Traverser.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/Traverser.scala
@@ -571,7 +571,7 @@ trait PathLengthTracker extends DepthFirstTraverser {
  * Finishing time of a node is time just after all `dir` neighbors of the node became finished
  * (or when it is visited if it has no `dir` neighbors that should be processed later).
  */
-trait DiscoveryAndDepthTimeTracker extends DepthFirstTraverser {
+trait DiscoveryAndFinishTimeTracker extends DepthFirstTraverser {
   private[this] var time: Int = _ // automatically initialized to 0 before first enqueue
 
   private lazy val discoveryTime = new IntInfoKeeper(false)

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/Traverser.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/Traverser.scala
@@ -15,12 +15,10 @@ package com.twitter.cassovary.graph
 
 import com.twitter.cassovary.graph.GraphDir._
 import com.twitter.cassovary.graph.GraphUtils.RandomWalkParams
-import com.twitter.cassovary.graph.tourist.{IntInfoKeeper, PrevNbrCounter}
+import com.twitter.cassovary.graph.tourist.{BoolInfoKeeper, IntInfoKeeper, PrevNbrCounter}
 import com.twitter.logging.Logger
-import com.twitter.ostrich.stats.Stats
 import it.unimi.dsi.fastutil.ints.IntArrayFIFOQueue
-import it.unimi.dsi.fastutil.objects.ObjectArrayList
-import scala.collection.mutable
+import scala.annotation.tailrec
 import scala.util.Random
 
 /**
@@ -38,24 +36,32 @@ trait Traverser extends Iterator[Node] { self =>
  * Bounds an iterator to go no more than a specified maximum number of steps
  */
 trait BoundedIterator[T] extends Iterator[T] {
-  val maxSteps: Long
+  /**
+   * @return If option is defined, it is the maximal number of elements the iterator returns.
+   *         If is `None`, the iteratator is not bounded.
+   */
+  def maxSteps: Option[Long]
+
   private var numStepsTaken = 0L
 
-  abstract override def next = {
+  abstract override def next() = {
     numStepsTaken += 1
-    super.next
+    super.next()
   }
 
-  abstract override def hasNext = ( (numStepsTaken < maxSteps) && super.hasNext)
+  abstract override def hasNext = maxSteps match {
+    case Some(max) if numStepsTaken >= max => false
+    case _ => super.hasNext
+  }
 }
 
 /**
- * Randomly traverse the graph, going from one node to a random neighbor in direction {@code dir}.
+ * Randomly traverse the graph, going from one node to a random neighbor in direction `dir`.
  * @param graph the graph to traverse on
  * @param dir direction in which to traverse
  * @param homeNodeIds the ids of nodes that the traverser will go to next if the node has no
- * neighbors, or we reset the traversal with probability {@code resetProbability},
- * or if the number of out-going edges at the current node exceeds {@code maxNumEdgesThresh}
+ * neighbors, or we reset the traversal with probability `resetProbability`,
+ * or if the number of out-going edges at the current node exceeds `maxNumEdgesThresh`
  * @param resetProbability the probability of teleporting back to home node set at each step
  * @param maxNumEdgesThresh if set, do not traverse edges with > maxNumEdgesThresh outgoing edges
  * @param onlyOnce specifies whether the same node should only be allowed to be visited once
@@ -68,13 +74,12 @@ trait BoundedIterator[T] extends Iterator[T] {
 class RandomTraverser(graph: Graph, dir: GraphDir, homeNodeIds: Seq[Int],
                       resetProbability: Double, maxNumEdgesThresh: Option[Int], onlyOnce: Boolean,
                       randNumGen: Random, maxDepth: Option[Int], filterHomeNodeByNumEdges: Boolean)
-    extends Traverser {  self =>
+  extends Traverser {  self =>
 
   private var currNode: Node = null
-  private var homeNode: Node = null
   private val homeNodeIdSet = Set(homeNodeIds: _*)
 
-  private val seenNodesTracker = new IntInfoKeeper(self.onlyOnce)
+  private val seenNodesTracker = new BoolInfoKeeper(self.onlyOnce)
 
   protected def seenBefore(id: Int) = seenNodesTracker.infoOfNode(id).isDefined
   private var pathLength = 0
@@ -86,21 +91,21 @@ class RandomTraverser(graph: Graph, dir: GraphDir, homeNodeIds: Seq[Int],
 
   private def takeRandomStep(): Int = {
     val nextRandom = randNumGen.nextDouble()
-    val needToFilterByNumEdges = (filterHomeNodeByNumEdges || !(homeNodeIdSet contains currNode.id))
+    val needToFilterByNumEdges = filterHomeNodeByNumEdges || !(homeNodeIdSet contains currNode.id)
     if (nextRandom < resetProbability ||
-        (needToFilterByNumEdges && NodeUtils.hasTooManyEdges(dir, maxNumEdgesThresh)(currNode))) {
+      (needToFilterByNumEdges && NodeUtils.hasTooManyEdges(dir, maxNumEdgesThresh)(currNode))) {
       goHome()
     } else {
       currNode.randomNeighbor(dir, randNumGen).getOrElse(goHome())
     }
   }
 
-  def next = {
+  def next() = {
     val nextNodeId = if (currNode == null ||
-        (maxDepth.isDefined && pathLength >= maxDepth.get)) {
+      (maxDepth.isDefined && pathLength >= maxDepth.get)) {
       goHome()
     } else {
-      var randNextNodeId = takeRandomStep()
+      val randNextNodeId = takeRandomStep()
       if (onlyOnce && seenBefore(randNextNodeId)) {
         seenNodesTracker.clear()
         goHome()
@@ -108,7 +113,7 @@ class RandomTraverser(graph: Graph, dir: GraphDir, homeNodeIds: Seq[Int],
         randNextNodeId
       }
     }
-    seenNodesTracker.recordInfo(nextNodeId, 0)
+    seenNodesTracker.recordInfo(nextNodeId, false)
     pathLength += 1
     currNode = getExistingNodeById(graph, nextNodeId)
 
@@ -119,166 +124,492 @@ class RandomTraverser(graph: Graph, dir: GraphDir, homeNodeIds: Seq[Int],
 }
 
 /**
- * Same as RandomTraverser except that the number of steps taken is bounded by {@code maxSteps}
+ * Same as RandomTraverser except that the number of steps taken is bounded by `maxSteps`
  */
-class RandomBoundedTraverser(graph: Graph, dir: GraphDir, homeNodeIds: Seq[Int], val maxSteps: Long,
+class RandomBoundedTraverser(graph: Graph, dir: GraphDir, homeNodeIds: Seq[Int], maxStepss: Long,
     walkParams: RandomWalkParams) extends RandomTraverser(graph, dir, homeNodeIds,
     walkParams.resetProbability, walkParams.maxNumEdgesThresh, walkParams.visitSameNodeOnce,
     walkParams.randNumGen, walkParams.maxDepth,
-    walkParams.filterHomeNodeByNumEdges) with BoundedIterator[Node]
+    walkParams.filterHomeNodeByNumEdges) with BoundedIterator[Node] {
+  val maxSteps: Option[Long] = Some(maxStepss)
+}
 
-/**
- * A traverser that keeps track of distance from homeNodeIds. If {@code onlyOnce} is true,
- * the same node is not traversed again.
- */
-abstract class DistanceTraverser[T](graph: Graph, homeNodeIds: Seq[Int], onlyOnce: Boolean)
-    extends Traverser { self =>
-
-  private val distanceTracker = new IntInfoKeeper(self.onlyOnce)
-
-  protected def init(defaultInfo: T) {
-    homeNodeIds foreach { id => visitPotentialNode(id, defaultInfo, 0) }
-  }
-
-  protected def visitPotentialNode(id: Int, info: T, dist: Int) {
-    val seen = seenBefore(id)
-    if (!(onlyOnce && seen)) {
-      storeForVisit(id, info)
+object Walk {
+  /**
+   * Optional limit used for limiting depth or degree of nodes that are added
+   * to the queue.
+   */
+  class Limit(limit: Option[Int]) {
+    def isLimitReached(value: Int): Boolean = limit match {
+      case Some(d) if value >= d => true
+      case _ => false
     }
-    if (!seen) distanceTracker.recordInfo(id, dist)
   }
 
-  protected def storeForVisit(id: Int, info: T)
+  /**
+   * We use node colors in the QueueBasedTraverser. We use
+   * 3 colors defined as `NodeColor`.
+   */
+  object NodeColor extends Enumeration {
+    type Color = Value
+    val Unenqueued = Value
+    val Enqueued = Value
+    val Visited = Value
+  }
 
-  protected def seenBefore(id: Int) = distance(id).isDefined
+  /**
+   * Stores information of three colors assigned to node ids (Ints).
+   *
+   * Initially every node has color `Unenqueued`. When adding it to the
+   * queue for the first time, we mark it `Enqueued` and then `Visited`,
+   * when visiting it for the first time.
+   * There are no other color changes.
+   *
+   * Uses BoolInfoKeeper under the hood.
+   */
+  trait NodeColoring {
 
-  def distance(id: Int) = distanceTracker.infoOfNode(id)
+    import NodeColor._
+
+    val map = new BoolInfoKeeper(false)
+
+    def +=(kv: (Int, Color)) {
+      kv._2 match {
+        case Unenqueued => ()
+        case Enqueued => if (get(kv._1) == Unenqueued) map.recordInfo(kv._1, false)
+        case Visited => if (get(kv._1) != Visited) map.recordInfo(kv._1, true)
+      }
+    }
+
+    def get(number: Int): Color = {
+      map.infoOfNode(number) match {
+        case None => Unenqueued
+        case Some(false) => Enqueued
+        case Some(true) => Visited
+      }
+    }
+  }
+
+  /**
+   * Parameters used to limit Traversers defined below.
+   *
+   * @param maxDepth the maximum depth of nodes to visit
+   * @param maxNumEdgesThreshold threshold of the number of neighbors a node can have, if a node has more
+   *                             than the threshold value, we skip its children
+   * @param maxSteps number of steps the traverser makes
+   */
+  case class Limits(maxDepth: Option[Int] = None, maxNumEdgesThreshold: Option[Int] = None,
+                        maxSteps: Option[Long] = None) {
+    def this(depth: Int, numEdges: Int, steps: Long) = this(Some(depth), Some(numEdges), Some(steps))
+  }
+
 }
 
 /**
- * Traverses in breadth-first order. This implies that first all the neighbors of
- * {@code homeNodeIds} are visited, then their neighbors, etc.
+ * General schema for some Traversers (like BFS, DFS). 
+ * `QueueBasedTraverser` keeps nodes to visit next in a queue. 
+ * It iteratively visits nodes from the front of the queue in order based on the type of traversal
+ * and optionally adds new nodes to the queue.
+ */
+trait QueueBasedTraverser extends Traverser {
+  import Walk._
+
+  /**
+   * Graph to be traversed.
+   */
+  def graph: Graph
+
+  /**
+   * Nodes to start the traversal from.
+   */
+  def homeNodeIds: Seq[Int]
+
+  /**
+   * Direction of the walk.
+   */
+  def dir: GraphDir
+
+  /**
+   * The priority of nodes adding to the queue. `BFS` adds nodes at the
+   * end and `DFS` adds nodes at the beginning.
+   */
+  object GraphTraverserNodePriority extends Enumeration {
+    type GraphTraverserNodePriority = Value
+
+    val FIFO = Value
+    val LIFO = Value
+  }
+
+  import GraphTraverserNodePriority._
+
+  /**
+   * The priority of nodes adding to the queue.
+   */
+  def nodePriority: GraphTraverserNodePriority
+
+  /**
+   * Action performed when visiting node `node` (before iteratur retuns `node`).
+   * Should be implemented in subclass.
+   */
+  def visitNode(node: Node): Unit = {}
+
+  /**
+   * Queue that stores nodes to be visited next.
+   */
+  protected val queue = new IntArrayFIFOQueue()
+
+  /**
+   * Number of nodes ever enqueued in the `queue`.
+   */
+  protected var numEnqueuedEver = 0L
+
+  /**
+   * Optional counter of previous nodes to a given node.
+   */
+  lazy val prevNbrCounter: Option[PrevNbrCounter] = None
+
+  /**
+   * Depth of visit of a given node.
+   */
+  def depth(node: Int): Option[Int]
+
+  /**
+   * We mark nodes using 3 'colors': `Unenqueued`, `Enqueued`, `Visited`.
+   * Initially every node is implicitly marked with `Unenqueued`.
+   *
+   * Node is marked `Enqueued`, when we add it to the queue. We mark
+   * it `Visited` just before returning with iterator's `next` function.
+   */
+  lazy val coloring = new Walk.NodeColoring {}
+
+  /**
+   * Checks if the node of a given color should be enqueued.
+   */
+  def shouldBeEnqueued(color: Walk.NodeColor.Color): Boolean
+
+  /**
+   * Set to true to deque a node from the queue before processing.
+   */
+  val shouldBeDequeuedBeforeProcessing: Boolean = true
+
+  /**
+   * Options to limit traverser walk.
+   */
+  lazy val limits: Walk.Limits = Walk.Limits()
+
+  lazy val depthLimit: Limit = new Limit(limits.maxDepth)
+  lazy val degreeLimit: Limit = new Limit(limits.maxNumEdgesThreshold)
+  lazy val maxSteps: Option[Long] = limits.maxSteps
+
+  /**
+   * During initialization we enqueue `homeNodeIds`.
+   */
+  enqueue(homeNodeIds, None)
+
+  /**
+   * If the queue is longer than the number of nodes that can be visited due to
+   * `maxSteps` bound, cuts the list of nodes that are to be added to the queue
+   * in order not to add too many of them.
+   *
+   * Assumes that all nodes in the queue are being visited.
+   */
+  def limitAddedToQueue(nodes: Seq[Int]): Seq[Int] = {
+    maxSteps match {
+      case None => nodes
+      case Some(max) => if (max - numEnqueuedEver > Int.MaxValue) {
+        nodes
+      } else {
+        nodes.take((max - numEnqueuedEver).toInt)
+      }
+    }
+  }
+
+  /**
+   * Returns nodes ids that should be added to the queue after visiting `node`.
+   */
+  def chooseNodesToEnqueue(node: Node): Seq[Int] = {
+    val currDepth = depth(node.id).get
+
+    if (depthLimit.isLimitReached(currDepth) ||
+      degreeLimit.isLimitReached(node.neighborCount(dir))) {
+      Seq()
+    } else {
+      limitAddedToQueue(node.neighborIds(dir).filter(n => shouldBeEnqueued(coloring.get(n))))
+    }
+  }
+
+  /**
+   * Enqueues `nodes` added after `from` node is visited (or None
+   * when equeueing initial nodes).
+   */
+  protected def enqueue(nodes: Seq[Int], from: Option[Int]): Unit = {
+    numEnqueuedEver += nodes.size
+    nodes.foreach {
+      node => coloring += (node, NodeColor.Enqueued)
+    }
+    if (prevNbrCounter.isDefined && from.isDefined) {
+      nodes.foreach {
+        node => prevNbrCounter.get.recordPreviousNeighbor(node, from.get)
+      }
+    }
+    nodePriority match {
+      case GraphTraverserNodePriority.LIFO =>
+        nodes.reverse.foreach (node => queue.enqueueFirst(node))
+      case GraphTraverserNodePriority.FIFO =>
+        nodes.foreach (node => queue.enqueue(node))
+    }
+  }
+
+  /**
+   * Performs action needed when visiting a node.
+   */
+  protected def processNode(node : Node): Node = {
+    visitNode(node)
+    coloring += (node.id, NodeColor.Visited)
+    enqueue(chooseNodesToEnqueue(node), Some(node.id))
+    node
+  }
+
+  /**
+   * Finds in the queue the node that will be visited next.
+   */
+  protected def findNextNodeToVisit(): Option[Int] = {
+    if (queue.isEmpty)
+      None
+    else
+      Some(queue.firstInt())
+  }
+
+  def next() = {
+    findNextNodeToVisit() match {
+      case Some(nextId) =>
+        if (shouldBeDequeuedBeforeProcessing) queue.dequeueInt()
+        processNode(getExistingNodeById(graph, nextId))
+      case None =>
+        Iterator.empty.next()
+    }
+  }
+
+  def hasNext = findNextNodeToVisit().isDefined
+}
+
+/**
+ * A traverser that keeps track of first depth of visiting a given node.
+ */
+trait DepthTracker extends QueueBasedTraverser {
+
+  private lazy val depthTracker = new IntInfoKeeper(true)
+
+  abstract override protected def enqueue(nodes: Seq[Int], from: Option[Int]): Unit = {
+    val fromDepth = from.flatMap(depthTracker.infoOfNode).getOrElse(-1)
+    nodes foreach { id =>
+      depthTracker.recordInfo(id, fromDepth + 1)
+    }
+    super.enqueue(nodes, from)
+  }
+
+  def depth(id: Int) = depthTracker.infoOfNode(id)
+}
+
+/**
+ * Traverses in BFS order. This implies that first all the neighbors of
+ * `homeNodeIds` are visited, then their neighbors, etc.
  * @param graph the graph to traverse on
  * @param dir direction in which to traverse
- * @param homeNodeIds the ids of nodes that the BFS starts
- * @param maxDepth the maximum depth of nodes to visit in BFS
- * @param maxNumEdgesThresh threshold of the number of neighbors a node can have, if a node has more
- * than the threshold value, we skip its children in BFS
- * @param maxSteps number of steps in traversal
- * @param onlyOnce specifies whether the same node should only be allowed to be
- * visited once in any path
- * @param prevNbrCounter if set, tracks previous neighbors by occurrence
+ * @param homeNodeIds the ids of nodes that the walk starts from
+ * @param walkLimits limiting parameters
+ * @param bfsPrevNbrCounter if set, tracks previous neighbors by occurrence
  */
+class BreadthFirstTraverser(val graph: Graph, val dir: GraphDir, val homeNodeIds: Seq[Int],
+                            walkLimits: Walk.Limits = Walk.Limits(),
+                            bfsPrevNbrCounter: Option[PrevNbrCounter] = None)
+  extends DepthTracker
+  with BoundedIterator[Node]
+{
+  private val log = Logger.get()
 
-class BreadthFirstTraverser(graph: Graph, dir: GraphDir, homeNodeIds: Seq[Int],
-                            maxDepth: Option[Int], maxNumEdgesThresh: Option[Int], maxSteps: Long,
-                            onlyOnce: Boolean, prevNbrCounter: Option[PrevNbrCounter])
-    extends Traverser { self =>
+  override def nodePriority = GraphTraverserNodePriority.FIFO
 
-  private val log = Logger.get
-  // the number of items can be enqueued is bounded by maxSteps
-  // because we never need to enqueue more than maxSteps items
-  private var numEnqueuedEver = 0L
-  private val qu = new IntArrayFIFOQueue
+  override lazy val limits = walkLimits
 
-  private val depthTracker = new IntInfoKeeper(true)
+  override lazy val prevNbrCounter = bfsPrevNbrCounter
 
-  homeNodeIds foreach { id =>
-    depthTracker.recordInfo(id, 0)
-    enqueueNeighbors(id, 1)
+  override def visitNode(node: Node): Unit = {
+    val currDepth = depth(node.id).get
+    log.ifTrace { "visiting %d, nbrCount=%d, maxNumEdges=%d, depth=%d".format(node.id,
+      node.neighborCount(dir), limits.maxNumEdgesThreshold.getOrElse(-1), currDepth) }
+    super.visitNode(node)
   }
 
-  private def visitPotentialNode(id: Int, depth: Int) {
-    if (!(onlyOnce && seen(id))) {
-      qu.enqueue(id)
-      numEnqueuedEver += 1
-    }
-    depthTracker.recordInfo(id, depth)
-  }
-
-  private def enqueueNeighbors(nodeId: Int, newDepth: Int) {
-    val nd = getExistingNodeById(graph, nodeId)
-    if (maxNumEdgesThresh.isEmpty || (nd.neighborCount(dir) <= maxNumEdgesThresh.get)) {
-      nd.neighborIds(dir) foreach { id =>
-        // bound the total number of items that
-        // can be pushed into the queue by maxSteps
-        if (numEnqueuedEver < maxSteps) {
-          visitPotentialNode(id, newDepth)
-          if (prevNbrCounter.isDefined) {
-            prevNbrCounter.get.recordInfo(id, nodeId)
-          }
-        }
-      }
-    }
-  }
-
-  private[graph] def depth(id: Int) = depthTracker.infoOfNode(id)
-  private def seen(id: Int) = depth(id).isDefined
-
-  def next = {
-    val curr = qu.dequeueInt()
-    val currDepth = depth(curr).get
-    val nd = getExistingNodeById(graph, curr)
-    log.ifTrace { "visiting %d, nbrCount=%d, maxNumEdges=%d, depth=%d".format(curr,
-      nd.neighborCount(dir), maxNumEdgesThresh.getOrElse(-1), currDepth) }
-    val newDepth = currDepth + 1
-    enqueueNeighbors(curr, newDepth)
-    nd
-  }
-
-  def hasNext = if (qu.size == 0) {
-    Stats.incr("bfs_walk_request_exhausted_2nd_degree", 1)
-    false
-  } else {
-    maxDepth.isEmpty || depth(qu.firstInt()).get <= maxDepth.get
+  def shouldBeEnqueued(color: Walk.NodeColor.Color): Boolean = {
+    color == Walk.NodeColor.Unenqueued
   }
 }
 
-class DepthFirstTraverser(graph: Graph, dir: GraphDir, homeNodeIds: Seq[Int],
-    onlyOnce: Boolean)
-    extends DistanceTraverser[Int](graph, homeNodeIds, onlyOnce) {
+/**
+ * Traverses in FIFO (breadth first) order but without any limit on the
+ * number of times every node can be visited.
+ * Every time the walk visits a node, it adds all its neighbors (along direction `dir`)
+ * to the queue.
+ * @param graph the graph to traverse on
+ * @param dir direction in which to traverse
+ * @param homeNodeIds the ids of nodes that the walk starts from
+ * @param walkLimits limiting parameters
+ * @param apwPrevNbrCounter if set, tracks previous neighbors by occurrence
+ */
+class AllPathsWalk(val graph: Graph, val dir: GraphDir, val homeNodeIds: Seq[Int],
+                   walkLimits: Walk.Limits = Walk.Limits(),
+                   apwPrevNbrCounter: Option[PrevNbrCounter] = None)
+  extends DepthTracker
+  with BoundedIterator[Node]
+{
+  val onlyOnce = false
 
-  // stack keeps a tuple (node, child# of higher node in stack). Hence, top node
-  // of stack always has child# = -1
-  case class NodeDesc(val id: Int, val childOff: Int)
+  override lazy val limits = walkLimits
 
-  private val stack = new ObjectArrayList[NodeDesc]
+  override lazy val prevNbrCounter = apwPrevNbrCounter
 
-  init(-1)
+  override def nodePriority = GraphTraverserNodePriority.FIFO
 
-  protected def storeForVisit(id: Int, info: Int) { stack.add(NodeDesc(id, info)) }
+  override def shouldBeEnqueued(color: Walk.NodeColor.Color): Boolean = true
+}
 
-  private def firstNotYetVisitedNode(nd: Node, off: Int): Option[NodeDesc] = {
-    assert(off != -1)
-    if (off == nd.neighborCount(dir)) {
-      // no more children of this node left, go to its parent
-      if (stack.isEmpty) None else {
-        val topel = stack.remove(stack.size - 1)
-        firstNotYetVisitedNode(getExistingNodeById(graph, topel.id), topel.childOff + 1)
-      }
+/**
+ * Traverses in DFS order (every node can be visited only once).
+ * @param graph the graph to traverse on
+ * @param dir direction in which to traverse
+ * @param homeNodeIds the ids of nodes that the walk starts from
+ * @param walkLimits limiting parameters
+ */
+class DepthFirstTraverser(val graph: Graph, val dir: GraphDir, val homeNodeIds: Seq[Int],
+                                walkLimits: Walk.Limits = Walk.Limits())
+    extends DepthTracker
+    with BoundedIterator[Node]
+{
+  private val log = Logger.get()
+
+  override lazy val limits = walkLimits
+
+  override def nodePriority = GraphTraverserNodePriority.LIFO
+
+  override def visitNode(node: Node): Unit = {
+    log.ifTrace { "visiting %d, nbrCount=%d, depth=%d".format(node.id,
+      node.neighborCount(dir), depth(node.id).get) }
+    super.visitNode(node)
+  }
+
+  /**
+   * Seeks the next node that should be visited. We may need to skip
+   * some nodes, because it is possible that we add a node to the queue twice.
+   *
+   * Takes already visited nodes from the queue.
+   * Does not take the next node from the queue (in order to allow hasNext checking).
+   * */
+   @tailrec
+   override final def findNextNodeToVisit(): Option[Int] = {
+    if (queue.isEmpty) {
+      None
     } else {
-      val childId = nd.neighborIds(dir)(off)
-      if (onlyOnce && seenBefore(childId)) {
-        // try the next child
-        firstNotYetVisitedNode(nd, off + 1)
+      val next = queue.firstInt()
+      val visitedBefore = coloring.get(next) match {
+        case Walk.NodeColor.Visited => true
+        case _ => false
+      }
+      if (visitedBefore) {
+        handleVisitedInQueue(next)
+        findNextNodeToVisit()
       } else {
-        storeForVisit(nd.id, off)
-        Some(NodeDesc(childId, distance(nd.id).get + 1))
+        Some(next)
       }
     }
   }
 
-  def next = {
-    var NodeDesc(id, off) = stack.remove(stack.size - 1)
-    assert(off == -1)
-    val topnd = getExistingNodeById(graph, id)
-    val nextUnvisitedNode = firstNotYetVisitedNode(topnd, off + 1)
-    nextUnvisitedNode match {
-      case Some(NodeDesc(nodeId, dist)) => visitPotentialNode(nodeId, -1, dist)
-      case None => // do nothing
-    }
-    topnd
+  def handleVisitedInQueue(next: Int) {
+    queue.dequeueInt()
   }
 
-  def hasNext = !stack.isEmpty
+  // can't limit number of nodes added to the queue, because we skip some nodes
+  override def limitAddedToQueue(nodes: Seq[Int]): Seq[Int] = nodes
+
+  override def shouldBeEnqueued(color: Walk.NodeColor.Color): Boolean = color != Walk.NodeColor.Visited
+}
+
+
+/**
+ * A trait to be mixed in to the DepthFirstTraverser that keeps track of visiting distance
+ * from `homeNodeIds`.
+ *
+ * Note that DepthTracker for the DFS case returns the depth of first seeing a particular
+ * node. It does not have to be the same as the depth at which the node is visited.
+ */
+trait PathLengthTracker extends DepthFirstTraverser {
+  private lazy val nextVisitDistanceTracker = new IntInfoKeeper(false)
+  private lazy val visitDistanceTracker = new IntInfoKeeper(true)
+
+  abstract override protected def enqueue(nodes: Seq[Int], from: Option[Int]): Unit = {
+    val fromDistance = from.flatMap(visitDistanceTracker.infoOfNode).getOrElse(-1)
+    nodes foreach { id =>
+      nextVisitDistanceTracker.recordInfo(id, fromDistance + 1)
+    }
+    super.enqueue(nodes, from)
+  }
+
+  override def visitNode(node: Node) {
+    visitDistanceTracker.recordInfo(node.id, nextVisitDistanceTracker.infoOfNode(node).get)
+    super.visitNode(node)
+  }
+
+  def distance(id: Int) = visitDistanceTracker.infoOfNode(id)
+}
+
+/**
+ * Trait to be mixed in to the BFS/DFS traverser to add discovery and finishing
+ * times of a node.
+ *
+ * Discovery time of a node is time when the node is added to the queue for the first time.
+ *
+ * Finishing time of a node is time just after all `dir` neighbors of the node became finished
+ * (or when it is visited if it has no `dir` neighbors that should be processed later).
+ */
+trait DiscoveryAndDepthTimeTracker extends DepthFirstTraverser {
+  private[this] var time: Int = _ // automatically initialized to 0 before first enqueue
+
+  private lazy val discoveryTime = new IntInfoKeeper(false)
+
+  private lazy val finishingTime = new IntInfoKeeper(false)
+
+  override val shouldBeDequeuedBeforeProcessing = false
+
+  abstract override protected def enqueue(nodes: Seq[Int], from: Option[Int]): Unit = {
+    nodes.foreach {
+      node =>
+        if (discoveryTime(node).isEmpty) {
+          discoveryTime.recordInfo(node, time)
+          time += 1
+        }
+    }
+    super.enqueue(nodes, from)
+  }
+
+  override def handleVisitedInQueue(node: Int): Unit = {
+    if (finishingTime(node).isEmpty) {
+      finishingTime.recordInfo(node, time)
+      time += 1
+    }
+    super.handleVisitedInQueue(node)
+  }
+
+  /**
+   * @return Number of nodes discovered or finished before discovering node with `id`.
+   */
+  def discoveryTime(id: Int): Option[Int] = {
+    discoveryTime.infoOfNode(id)
+  }
+
+  /**
+   * @return Number of nodes discovered or finished before finishing node with `id`.
+   */
+  def finishingTime(id: Int): Option[Int] = {
+    finishingTime.infoOfNode(id)
+  }
 }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/tourist/BoolInfoKeeper.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/tourist/BoolInfoKeeper.scala
@@ -10,22 +10,12 @@
  * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- */
+*/
 package com.twitter.cassovary.graph.tourist
 
-import com.twitter.cassovary.graph.Node
+import com.twitter.cassovary.util.FastUtilUtils
 
-/**
- * Represents the processing done when visiting a node.
- */
-trait NodeTourist {
-  /**
-   * Visit a node by its `id`
-   */
-  def visit(id: Int)
+class BoolInfoKeeper(override val onlyOnce: Boolean) extends InfoKeeper[Boolean] {
 
-  /**
-   * Visit a `node`
-   */
-  def visit(node: Node) { visit(node.id) }
+  protected val infoPerNode = FastUtilUtils.newInt2BooleanOpenHashMap()
 }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/tourist/InfoKeeper.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/tourist/InfoKeeper.scala
@@ -14,39 +14,50 @@
 package com.twitter.cassovary.graph.tourist
 
 import com.twitter.cassovary.graph.Node
-import it.unimi.dsi.fastutil.ints.{Int2IntMap, Int2ObjectOpenHashMap}
+import scala.collection.mutable
 
 /**
- * Info keeper records info per node and returns output per node or for all nodes
+ * Info keeper records info per node id and returns output per node or for all nodes
  */
-trait InfoKeeper[@specialized(Int) I, @specialized(Int) O, M] {
+trait InfoKeeper[@specialized(Int, Boolean) O] {
+
+  protected def infoPerNode: mutable.Map[Int, O]
+
   /**
    * Keep info only the first time a node is seen
    */
   val onlyOnce = false
 
   /**
-   * Record information {@code info} of node {@code id}
+   * Record information `info` of node `id`
    */
-  def recordInfo(id: Int, info: I)
+  def recordInfo(id: Int, info: O) {
+    if (!(onlyOnce && infoAllNodes.contains(id))) {
+      infoPerNode.put(id, info)
+    }
+  }
 
   /**
-   * Get information of a paticular node by its {@code id}
+   * Get information of a paticular node by its `id`
    */
-  def infoOfNode(id: Int): Option[O]
+  def infoOfNode(id: Int): Option[O] = {
+    infoAllNodes.get(id)
+  }
 
   /**
-   * Get information of a particular {@code node}.
+   * Get information of a particular `node`.
    */
   def infoOfNode(node: Node): Option[O] = infoOfNode(node.id)
 
   /**
    * Clear underlying map
    */
-  def clear()
+  def clear() {
+    infoPerNode.clear()
+  }
 
   /**
-   * Get info for all nodes
+   * Get info for all nodes (immutable version visible outside)
    */
-  def infoAllNodes: M
+  def infoAllNodes: collection.Map[Int, O] = infoPerNode
 }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/tourist/IntInfoKeeper.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/tourist/IntInfoKeeper.scala
@@ -14,52 +14,17 @@
 
 package com.twitter.cassovary.graph.tourist
 
-import com.twitter.cassovary.graph.Node
-import it.unimi.dsi.fastutil.ints.{Int2IntMap, Int2IntOpenHashMap}
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap
+import java.util
+import scala.collection.JavaConversions._
+import scala.collection.mutable
 
 /**
  * An InfoKeeper keeps caller-supplied info per node.
  * It provides another method recordInfo() to record a given info for a node.
  */
-class IntInfoKeeper(override val onlyOnce: Boolean) extends InfoKeeper[Int, Int, Int2IntMap] {
+class IntInfoKeeper(override val onlyOnce: Boolean) extends InfoKeeper[Int] {
+  protected val underlyingMap =  new Int2IntOpenHashMap
 
-  protected val infoPerNode = new Int2IntOpenHashMap
-
-  /**
-   * Record information {@code info} of node {@code id}.
-   */
-  def recordInfo(id: Int, info: Int) {
-    if (!(onlyOnce && infoPerNode.containsKey(id))) {
-      infoPerNode.put(id, info)
-    }
-  }
-
-  def incrementInfo(id: Int, increment: Int) {
-    if (!(onlyOnce && infoPerNode.containsKey(id))) {
-      infoPerNode.add(id, increment)
-    }
-  }
-
-  /**
-   * Get information of a particular node by its {@code id}
-   */
-  def infoOfNode(id: Int): Option[Int] = {
-    if (infoPerNode.containsKey(id)) {
-      Some(infoPerNode.get(id))
-    } else {
-      None
-    }
-  }
-
-  /**
-   * Clear underlying map
-   */
-  def clear() {
-    infoPerNode.clear()
-  }
-
-  /**
-   * Get info for all nodes as an array of (key, value) tuples
-   */
-  def infoAllNodes: Int2IntMap = infoPerNode
+  override protected def infoPerNode: mutable.Map[Int, Int] = underlyingMap.asInstanceOf[util.Map[Int, Int]]
 }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/tourist/PathsCounter.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/tourist/PathsCounter.scala
@@ -14,20 +14,20 @@
 package com.twitter.cassovary.graph.tourist
 
 import com.twitter.cassovary.graph.{DirectedPath, DirectedPathCollection}
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap
 import it.unimi.dsi.fastutil.objects.Object2IntMap
+import java.{util => jutil}
+import scala.collection.JavaConversions.mapAsScalaMap
 
 /**
  * A tourist that keeps track of the paths ending at each node. It keeps
- * at {@code numTopPathsPerNode} paths per node.
+ * at most `numTopPathsPerNode` paths per node.
  *
  * TODO: instead of homeNodeIds, this func should take
  * a function param of Node => Boolean
  */
 
 class PathsCounter(numTopPathsPerNode: Int, homeNodeIds: Seq[Int])
-    extends NodeTourist with InfoKeeper[Int, Object2IntMap[DirectedPath],
-      Int2ObjectMap[Object2IntMap[DirectedPath]]] {
+    extends NodeTourist with InfoKeeper[Object2IntMap[DirectedPath]] {
 
   def this() = this(0, Nil)
 
@@ -40,11 +40,11 @@ class PathsCounter(numTopPathsPerNode: Int, homeNodeIds: Seq[Int])
     paths.appendToCurrentPath(id)
   }
 
-  def recordInfo(id: Int, info: Int) {
-    // NOOP use visit
+  override def recordInfo(id: Int, info: Object2IntMap[DirectedPath]) {
+    throw new UnsupportedOperationException("Use visit method instead")
   }
 
-  def infoOfNode(id: Int): Option[Object2IntMap[DirectedPath]] = {
+  override def infoOfNode(id: Int): Option[Object2IntMap[DirectedPath]] = {
     if (paths.containsNode(id)) {
       Some(paths.topPathsTill(id, numTopPathsPerNode))
     } else {
@@ -52,9 +52,10 @@ class PathsCounter(numTopPathsPerNode: Int, homeNodeIds: Seq[Int])
     }
   }
 
-  def infoAllNodes: Int2ObjectMap[Object2IntMap[DirectedPath]] = paths.topPathsPerNodeId(numTopPathsPerNode)
+  def infoPerNode = mapAsScalaMap(paths.topPathsPerNodeId(numTopPathsPerNode)
+    .asInstanceOf[jutil.Map[Int, Object2IntMap[DirectedPath]]])
 
-  def clear() {
+  override def clear() {
     paths.clear()
   }
 }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/util/FastUtilUtils.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/util/FastUtilUtils.scala
@@ -12,12 +12,17 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package com.twitter.cassovary.graph.util
+package com.twitter.cassovary.util
 
-import it.unimi.dsi.fastutil.ints.Int2IntMap
+import java.{util => jutil}
+
+import it.unimi.dsi.fastutil.ints.{Int2BooleanOpenHashMap, Int2IntMap, Int2IntOpenHashMap}
 import it.unimi.dsi.fastutil.objects.Object2IntMap
 
-object FastUtilConversion {
+import scala.collection.JavaConversions._
+import scala.collection.mutable
+
+object FastUtilUtils {
 
   def object2IntMapToArray[T](map: Object2IntMap[T]): Array[(T, Int)] = {
     val result = new Array[(T, Int)](map.size)
@@ -47,4 +52,13 @@ object FastUtilConversion {
     result
   }
 
+  def int2IntMapToMap(map: Int2IntMap): mutable.Map[Int, Int] = {
+    map.asInstanceOf[jutil.Map[Int, Int]]
+  }
+
+  def newInt2BooleanOpenHashMap(): mutable.Map[Int, Boolean] =
+    new Int2BooleanOpenHashMap().asInstanceOf[jutil.Map[Int, Boolean]]
+
+  def newInt2IntOpenHashMap(): mutable.Map[Int, Int] =
+    new Int2IntOpenHashMap().asInstanceOf[jutil.Map[Int, Int]]
 }

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/DirectedPathCollectionSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/DirectedPathCollectionSpec.scala
@@ -13,7 +13,7 @@
  */
 package com.twitter.cassovary.graph
 
-import com.twitter.cassovary.graph.util.FastUtilConversion
+import com.twitter.cassovary.util.FastUtilUtils
 import it.unimi.dsi.fastutil.objects.Object2IntMap
 import org.junit.runner.RunWith
 import org.scalatest.WordSpec
@@ -101,9 +101,10 @@ class DirectedPathCollectionSpec extends WordSpec with ShouldMatchers {
         paths.totalNumPaths shouldEqual 10
       }
     }
+  }
 
-    def pathMapToSeq(map: Object2IntMap[DirectedPath]) = {
-      FastUtilConversion.object2IntMapToArray(map).toSeq
-    }
+
+  def pathMapToSeq(map: Object2IntMap[DirectedPath]) = {
+    FastUtilUtils.object2IntMapToArray(map).toSeq
   }
 }

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/TraverserSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/TraverserSpec.scala
@@ -13,26 +13,34 @@
  */
 package com.twitter.cassovary.graph
 
-import org.scalatest.mock.MockitoSugar
+import org.mockito.Mockito._
 import org.scalatest.WordSpec
 import org.scalatest.matchers.ShouldMatchers
-import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+
 import scala.util.Random
 
 class TraverserSpec extends WordSpec with MockitoSugar with ShouldMatchers {
 
   class TestIter extends Iterator[Int] {
     var i = 0
-    def next = { i += 10 ; i }
-    def hasNext = (i < 40)
+    def next() = { i += 10 ; i }
+    def hasNext = i < 40
   }
 
   "BoundedIterator" should {
     "satisfy a limit" in {
       val biter = new TestIter with BoundedIterator[Int] {
-        lazy val maxSteps = 3L
+        lazy val maxSteps = Some(3L)
       }
       biter.toSeq.toList shouldEqual List(10, 20, 30)
+    }
+
+    "be unlimited when limit is None" in {
+      val biter = new TestIter with BoundedIterator[Int] {
+        lazy val maxSteps = None
+      }
+      biter.toSeq.toList shouldEqual List(10, 20, 30, 40)
     }
    }
 
@@ -56,7 +64,7 @@ class TraverserSpec extends WordSpec with MockitoSugar with ShouldMatchers {
       }
     }
 
-    "test onlyOnce option on graph3, when it is set to true, walk should reset to homenode" +
+    "test onlyOnce option on graph3, when it is set to true, walk should reset to homenode " +
         "when visit the same node twice, even when resetprob equals 0, " +
         "if option not set, walk will run into infinite loop" in {
       val mockRandom = mock[Random]
@@ -71,9 +79,11 @@ class TraverserSpec extends WordSpec with MockitoSugar with ShouldMatchers {
         val randomTraverser = new RandomTraverser(
             graph3, dir, Seq(10), resetProb, None, true, mockRandom, None, false)
         val homeNode = getNode(10)
+
         when(mockRandom.nextInt(1)).thenReturn(0)
-        randomTraverser.next shouldEqual homeNode
         when(mockRandom.nextInt(2)).thenReturn(1)
+        randomTraverser.next shouldEqual homeNode
+
         var next = randomTraverser.next
         next.id shouldEqual 12
         next = randomTraverser.next
@@ -86,31 +96,31 @@ class TraverserSpec extends WordSpec with MockitoSugar with ShouldMatchers {
       }
     }
 
-    "test onlyOnce option on graph6, when it is set to true, walk should reset to homenode " +
-        "when visit the same node twice, even when resetprob equals 0" in {
+    "test onlyOnce option on graph6, when it is set to true, walk should reset to homenode when " +
+        "visit the same node twice, even when resetprob equals 0" in {
       val mockRandom = mock[Random]
       //mock random always returns the last element
-      when(mockRandom.nextDouble()).thenReturn(1.0)
+      when(mockRandom.nextDouble()) thenReturn 1.0
 
       val resetProb = 0.0
       List(GraphDir.OutDir, GraphDir.InDir) foreach { dir =>
         val dir = GraphDir.OutDir
         val randomTraverser = new RandomTraverser(graph, dir, Seq(12),
-            resetProb, None, true, mockRandom, None, false)
+          resetProb, None, true, mockRandom, None, false)
         val homeNode = getNode(12)
-        when(mockRandom.nextInt(1)).thenReturn(0)
+        when(mockRandom.nextInt(1)) thenReturn 0
         randomTraverser.next shouldEqual homeNode
-        var next = randomTraverser.next
+        var next = randomTraverser.next()
         next.id shouldEqual 14
-        next = randomTraverser.next
+        when(mockRandom.nextInt(2)) thenReturn 1
+        next = randomTraverser.next()
         next.id shouldEqual 15
         //node 15 has 2 neighbors (10,11), we visit 11
-        when(mockRandom.nextInt(2)).thenReturn(1)
-        next = randomTraverser.next
+        next = randomTraverser.next()
         next.id shouldEqual 11
         //11 has 2 neighbors (12,14), our mockRandom will pick 14
         //but 14 has been visited before, reset back to homenode(12)
-        next = randomTraverser.next
+        next = randomTraverser.next()
         next.id shouldEqual 12
       }
     }
@@ -123,7 +133,7 @@ class TraverserSpec extends WordSpec with MockitoSugar with ShouldMatchers {
           None, false, new Random, None, false)
         val homeNode = getNode(10)
         randomTraverser.next shouldEqual homeNode
-        var curr = homeNode
+        val curr = homeNode
         for (i <- 1 to 10) {
           randomTraverser.next shouldEqual curr
         }
@@ -134,15 +144,13 @@ class TraverserSpec extends WordSpec with MockitoSugar with ShouldMatchers {
   "BreadthFirstTraverser" should {
     val graph = TestGraphs.g6
 
-    "yield all nodes in BFS order in non-unique id walk" in {
+    "yield all nodes in BFS order in id walk with correct discovery times" in {
       val dir = GraphDir.OutDir
-      val bfs = new BreadthFirstTraverser(graph, dir, Seq(10),
-        Some(5), None, 10L, false, None) with BoundedIterator[Node] {
-        lazy val maxSteps = 10L
-      }
-
+      val bfs = new BreadthFirstTraverser(graph, dir, Seq(10), Walk.Limits(Some(5),
+          None, Some(10L)))
       val ids = bfs.toSeq.map { _.id }.toList
-      ids shouldEqual List(11, 12, 13, 12, 14, 14, 12, 14, 14, 15)
+
+      ids shouldEqual List(10, 11, 12, 13, 14, 15)
       bfs.depth(10) shouldEqual Some(0)
       List(11, 12, 13) foreach { bfs.depth(_) shouldEqual Some(1) }
       List(14) foreach { bfs.depth(_) shouldEqual Some(2) }
@@ -150,43 +158,70 @@ class TraverserSpec extends WordSpec with MockitoSugar with ShouldMatchers {
       bfs.depth(16) shouldEqual None
     }
 
-    "yield all nodes in BFS order in unique id walk" in {
+    "yield all nodes in BFS order walk with constraint maxDepth" in {
       val dir = GraphDir.OutDir
-      val bfs = new BreadthFirstTraverser(graph, dir, Seq(10), Some(5),
-          None, 10L, true, None) with BoundedIterator[Node] {
-        lazy val maxSteps = 10L
-      }
+      val bfs = new BreadthFirstTraverser(graph, dir, Seq(15), Walk.Limits(Some(1),
+        None, Some(10L)), None)
+
       val ids = bfs.toSeq.map { _.id }.toList
-      ids shouldEqual List(11, 12, 13, 14, 15)
-      bfs.depth(10) shouldEqual Some(0)
-      List(11, 12, 13) foreach { bfs.depth(_) shouldEqual Some(1) }
-      List(14) foreach { bfs.depth(_) shouldEqual Some(2) }
-      List(15) foreach { bfs.depth(_) shouldEqual Some(3) }
-      bfs.depth(16) shouldEqual None
+      ids shouldEqual List(15, 10, 11)
+      bfs.depth(15) shouldEqual Some(0)
+      List(10, 11) foreach { bfs.depth(_) shouldEqual Some(1) }
+      List(13, 16) foreach { bfs.depth(_) shouldEqual None }
     }
 
     "yield all nodes in BFS order walk with constraint numOfFriendsThresh" in {
       val dir = GraphDir.OutDir
-      val bfs = new BreadthFirstTraverser(graph, dir, Seq(15), Some(5),
-          Some(2), 10L, false, None) with BoundedIterator[Node] {
-        lazy val maxSteps = 10L
-      }
+      val bfs = new BreadthFirstTraverser(graph, dir, Seq(15), new Walk.Limits(5, 3, 10L))
+
       val ids = bfs.toSeq.map { _.id }.toList
-      ids shouldEqual List(10, 11, 12, 14, 14, 15, 15, 10, 11, 10)
+      ids shouldEqual List(15, 10, 11, 12, 14)
       bfs.depth(15) shouldEqual Some(0)
       List(10, 11) foreach { bfs.depth(_) shouldEqual Some(1) }
       List(12, 14) foreach { bfs.depth(_) shouldEqual Some(2) }
       List(13, 16) foreach { bfs.depth(_) shouldEqual None }
     }
+
+    "yield all nodes in BFS order walk with constraint maxSteps" in {
+      val dir = GraphDir.OutDir
+      val bfs = new BreadthFirstTraverser(graph, dir, Seq(15), new Walk.Limits(5, 3, 4L))
+
+      val ids = bfs.toSeq.map { _.id }.toList
+      ids shouldEqual List(15, 10, 11, 12)
+      bfs.depth(15) shouldEqual Some(0)
+      List(10, 11) foreach { bfs.depth(_) shouldEqual Some(1) }
+      List(12) foreach { bfs.depth(_) shouldEqual Some(2) }
+      List(13, 16) foreach { bfs.depth(_) shouldEqual None }
+    }
   }
 
   "DepthFirstTraverser" should {
-    val graph = TestGraphs.g6
+    "yield all nodes in DFS order with expected finishing times" in {
+      val trav = new DepthFirstTraverser(TestGraphs.g5, GraphDir.OutDir, Seq(10))
+        with DiscoveryAndDepthTimeTracker
+      val ids = trav.toSeq.map(_.id).toList
+      ids shouldEqual List(10, 11, 12, 13, 14)
 
-    "yield all nodes in DFS order in expected order in unique id walk (outDir)" in {
+      trav.finishingTime(10) shouldEqual Some(9)
+      trav.finishingTime(11) shouldEqual Some(5)
+      trav.finishingTime(12) shouldEqual Some(4)
+      trav.finishingTime(13) shouldEqual Some(8)
+      trav.finishingTime(14) shouldEqual Some(7)
+
+      trav.discoveryTime(10) shouldEqual Some(0)
+      trav.discoveryTime(11) shouldEqual Some(1)
+      trav.discoveryTime(12) shouldEqual Some(2)
+      trav.discoveryTime(13) shouldEqual Some(3)
+      trav.discoveryTime(14) shouldEqual Some(6)
+    }
+
+    val graph = TestGraphs.g6
+    "yield all nodes in DFS order in expected order (outDir)" in {
       val dir = GraphDir.OutDir
-      val trav = new DepthFirstTraverser(graph, dir, Seq(10), true)
+      val trav = new DepthFirstTraverser(graph, dir, Seq(10))
+        with PathLengthTracker with DiscoveryAndDepthTimeTracker
       val ids = trav.toSeq.map { _.id }.toList
+
       ids shouldEqual List(10, 11, 12, 14, 15, 13)
 
       trav.distance(10) shouldEqual Some(0)
@@ -195,27 +230,28 @@ class TraverserSpec extends WordSpec with MockitoSugar with ShouldMatchers {
       trav.distance(14) shouldEqual Some(3)
       trav.distance(15) shouldEqual Some(4)
       trav.distance(13) shouldEqual Some(1)
-    }
 
-    "yield all nodes in DFS order in expected order in non-unique id walk (outDir)" in {
-      val dir = GraphDir.OutDir
-      val trav = new DepthFirstTraverser(graph, dir, Seq(10), false) with BoundedIterator[Node] {
-        lazy val maxSteps = 7L
-      }
-      val ids = trav.toSeq.map { _.id }.toList
-      ids shouldEqual List(10, 11, 12, 14, 15, 10, 11)
+      trav.finishingTime(10) shouldEqual Some(11)
+      trav.finishingTime(11) shouldEqual Some(9)
+      trav.finishingTime(12) shouldEqual Some(8)
+      trav.finishingTime(13) shouldEqual Some(10)
+      trav.finishingTime(14) shouldEqual Some(7)
+      trav.finishingTime(15) shouldEqual Some(6)
 
-      trav.distance(10) shouldEqual Some(0)
-      trav.distance(11) shouldEqual Some(1)
-      trav.distance(12) shouldEqual Some(2)
+      trav.discoveryTime(10) shouldEqual Some(0)
+      trav.discoveryTime(11) shouldEqual Some(1)
+      trav.discoveryTime(12) shouldEqual Some(2)
+      trav.discoveryTime(13) shouldEqual Some(3)
+      trav.discoveryTime(14) shouldEqual Some(4)
+      trav.discoveryTime(15) shouldEqual Some(5)
     }
 
     "yield all nodes in DFS order in expected order in unique id walk (inDir)" in {
       val dir = GraphDir.InDir
-      val trav = new DepthFirstTraverser(graph, dir, Seq(10), true) with BoundedIterator[Node] {
-        lazy val maxSteps = 11L
-      }
+      val trav = new DepthFirstTraverser(graph, dir, Seq(10), Walk.Limits(None, None, Some(10L)))
+        with PathLengthTracker with DiscoveryAndDepthTimeTracker
       val ids = trav.toSeq.map { _.id }.toList
+
       ids shouldEqual List(10, 15, 14, 11, 12, 13)
 
       trav.distance(10) shouldEqual Some(0)
@@ -224,6 +260,51 @@ class TraverserSpec extends WordSpec with MockitoSugar with ShouldMatchers {
       trav.distance(11) shouldEqual Some(3)
       trav.distance(12) shouldEqual Some(3)
       trav.distance(13) shouldEqual Some(4)
+
+      trav.finishingTime(10) shouldEqual Some(11)
+      trav.finishingTime(11) shouldEqual Some(6)
+      trav.finishingTime(12) shouldEqual Some(8)
+      trav.finishingTime(13) shouldEqual Some(7)
+      trav.finishingTime(14) shouldEqual Some(9)
+      trav.finishingTime(15) shouldEqual Some(10)
+
+      trav.discoveryTime(10) shouldEqual Some(0)
+      trav.discoveryTime(11) shouldEqual Some(3)
+      trav.discoveryTime(12) shouldEqual Some(4)
+      trav.discoveryTime(13) shouldEqual Some(5)
+      trav.discoveryTime(14) shouldEqual Some(2)
+      trav.discoveryTime(15) shouldEqual Some(1)
+    }
+  }
+
+  "AllPathsWalk" should {
+    val graph = TestGraphs.g6
+
+    "yield nodes in All Paths Walk with first visit depth (outDir)" in {
+      val dir = GraphDir.OutDir
+      val trav = new AllPathsWalk(graph, dir, Seq(10), Walk.Limits(Some(2), None, Some(6)))
+      val ids = trav.toSeq.map { _.id }.toList
+      ids shouldEqual List(10, 11, 12, 13, 12, 14)
+
+      trav.depth(10) shouldEqual Some(0)
+      trav.depth(11) shouldEqual Some(1)
+      trav.depth(12) shouldEqual Some(1)
+      trav.depth(13) shouldEqual Some(1)
+      trav.depth(14) shouldEqual Some(2)
+    }
+
+    "yield all nodes in All Paths Walk with first visit depth (inDir)" in {
+      val dir = GraphDir.InDir
+      val trav = new AllPathsWalk(graph, dir, Seq(10), Walk.Limits(None, None, Some(10)))
+      val ids = trav.toSeq.map { _.id }.toList
+      ids shouldEqual List(10, 15, 14, 11, 12, 13, 10, 15, 10, 11)
+
+      trav.depth(10) shouldEqual Some(0)
+      trav.depth(15) shouldEqual Some(1)
+      trav.depth(14) shouldEqual Some(2)
+      trav.depth(11) shouldEqual Some(3)
+      trav.depth(12) shouldEqual Some(3)
+      trav.depth(13) shouldEqual Some(3)
     }
   }
 }

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/TraverserSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/TraverserSpec.scala
@@ -198,7 +198,7 @@ class TraverserSpec extends WordSpec with MockitoSugar with ShouldMatchers {
   "DepthFirstTraverser" should {
     "yield all nodes in DFS order with expected finishing times" in {
       val trav = new DepthFirstTraverser(TestGraphs.g5, GraphDir.OutDir, Seq(10))
-        with DiscoveryAndDepthTimeTracker
+        with DiscoveryAndFinishTimeTracker
       val ids = trav.toSeq.map(_.id).toList
       ids shouldEqual List(10, 11, 12, 13, 14)
 
@@ -219,7 +219,7 @@ class TraverserSpec extends WordSpec with MockitoSugar with ShouldMatchers {
     "yield all nodes in DFS order in expected order (outDir)" in {
       val dir = GraphDir.OutDir
       val trav = new DepthFirstTraverser(graph, dir, Seq(10))
-        with PathLengthTracker with DiscoveryAndDepthTimeTracker
+        with PathLengthTracker with DiscoveryAndFinishTimeTracker
       val ids = trav.toSeq.map { _.id }.toList
 
       ids shouldEqual List(10, 11, 12, 14, 15, 13)
@@ -249,7 +249,7 @@ class TraverserSpec extends WordSpec with MockitoSugar with ShouldMatchers {
     "yield all nodes in DFS order in expected order in unique id walk (inDir)" in {
       val dir = GraphDir.InDir
       val trav = new DepthFirstTraverser(graph, dir, Seq(10), Walk.Limits(None, None, Some(10L)))
-        with PathLengthTracker with DiscoveryAndDepthTimeTracker
+        with PathLengthTracker with DiscoveryAndFinishTimeTracker
       val ids = trav.toSeq.map { _.id }.toList
 
       ids shouldEqual List(10, 15, 14, 11, 12, 13)

--- a/cassovary-examples/src/main/java/RandomWalkJava.java
+++ b/cassovary-examples/src/main/java/RandomWalkJava.java
@@ -18,25 +18,14 @@
 
 import com.google.common.base.Functions;
 import com.google.common.collect.Ordering;
-import com.twitter.cassovary.graph.DirectedGraph;
-import com.twitter.cassovary.graph.DirectedPath;
-import com.twitter.cassovary.graph.GraphDir;
-import com.twitter.cassovary.graph.GraphUtils;
+import com.twitter.cassovary.graph.*;
 import com.twitter.cassovary.graph.GraphUtils.RandomWalkParams;
-import com.twitter.cassovary.graph.StoredGraphDir;
-import com.twitter.cassovary.graph.TestGraphs;
-import com.twitter.util.Duration;
-import it.unimi.dsi.fastutil.ints.Int2IntMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import java.lang.Integer;
-import java.lang.System;
-import java.util.Comparator;
+import scala.Tuple2;
+import scala.collection.JavaConverters$;
+
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
-import scala.Option;
-import scala.Tuple2;
 
 public class RandomWalkJava {
 
@@ -61,10 +50,11 @@ public class RandomWalkJava {
     // Do the walk and measure how long it took
     System.out.printf("Now doing a random walk of %s steps from Node 0...\n", numSteps);
     long startTime = System.nanoTime();
-    Tuple2<Int2IntMap, scala.Option<Int2ObjectMap<Object2IntMap<DirectedPath>>>> lm =
+    Tuple2<scala.collection.Map<Object, Object>, scala.Option<scala.collection.Map<Object,
+            Object2IntMap<DirectedPath>>>> lm =
             graphUtils.calculatePersonalizedReputation(0, walkParams);
     long endTime = System.nanoTime();
-    Int2IntMap neighbors = lm._1;
+    Map<Integer, Integer> neighbors = scalaIntsMapToJavaMap(lm._1());
     System.out.printf("Random walk visited %s nodes in %s ms:\n", neighbors.size(), (endTime - startTime)/1000000);
 
     // Sort neighbors (or nodes) in descending number of visits and take the top 10 neighbors
@@ -78,8 +68,8 @@ public class RandomWalkJava {
     for (int id : topNeighbors) {
       int numVisits = neighbors.get(id);
       System.out.printf("%8s%10s\t", id, numVisits);
-      if (lm._2.isDefined()) { // If Option is not None
-        Object2IntMap<DirectedPath> paths = lm._2.get().get(id);
+      if (lm._2().isDefined()) { // If Option is not None
+        Object2IntMap<DirectedPath> paths = lm._2().get().apply(id);
         int remaining = paths.size();
         for (Map.Entry<DirectedPath, Integer> ef : paths.entrySet()) {
           // Print a directed path and #visits along that path
@@ -95,5 +85,10 @@ public class RandomWalkJava {
       }
       System.out.println();
     }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<Integer, Integer> scalaIntsMapToJavaMap(scala.collection.Map<Object, Object> map) {
+    return (Map<Integer, Integer>) JavaConverters$.MODULE$.mapAsJavaMapConverter(map);
   }
 }

--- a/cassovary-examples/src/main/scala/RandomWalk.scala
+++ b/cassovary-examples/src/main/scala/RandomWalk.scala
@@ -42,7 +42,7 @@ object RandomWalk {
     printf("%8s%10s\t%s\n", "NodeId", "#Visits", "Top 2 Paths with counts")
     topNeighbors.toList.sortWith((x1, x2) => x2._2.intValue < x1._2.intValue).take(10).foreach { case (id, numVisits) =>
       if (paths.isDefined) {
-        val topPaths = paths.get.get(id).map { case (DirectedPath(nodes), count) =>
+        val topPaths = paths.get(id).map { case (DirectedPath(nodes), count) =>
           nodes.mkString("->") + " (%s)".format(count)
         }
         printf("%8s%10s\t%s\n", id, numVisits, topPaths.mkString(" | "))


### PR DESCRIPTION
Added abstract class QueueBasedTraverser holds general logic for most
traversers.
Fixed errors in InfoKeepers.
Added InfoKeeper that uses IntToBoolean fastutil map to store Boolean
values.
Changed BreadthFirstTraverser so that first node is the node we start
traverse from (to be consistent with other traversals).