### PR TITLE
Node tourist spec migr

### DIFF
--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/NodeTouristSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/NodeTouristSpec.scala
@@ -17,24 +17,25 @@ import com.twitter.cassovary.graph.tourist.{VisitsCounter, PathsCounter}
 import com.twitter.cassovary.graph.util.FastUtilConversion
 import it.unimi.dsi.fastutil.ints.Int2IntMap
 import it.unimi.dsi.fastutil.objects.Object2IntMap
-import org.specs.Specification
+import org.scalatest.WordSpec
+import org.scalatest.matchers.ShouldMatchers
 
-class NodeTouristSpec extends Specification {
+class NodeTouristSpec extends WordSpec with ShouldMatchers {
 
   def testNode(id: Int) = TestNode(id, Nil, Nil)
 
-  "visitscounter" should {
+  "VisitsCounter" should {
     "count visits properly" in {
       val visitor = new VisitsCounter
       List(1, 2, 3, 1, 2, 3, 1, 4, 2) foreach { id: Int =>
         visitor.visit(testNode(id))
       }
 
-      visitMapToSeq(visitor.infoAllNodes) mustEqual Array((1, 3), (2, 3), (3, 2), (4, 1)).toSeq
+      visitMapToSeq(visitor.infoAllNodes) shouldEqual Array((1, 3), (2, 3), (3, 2), (4, 1)).toSeq
     }
   }
 
-  "pathscounter" should {
+  "PathsCounter" should {
     "count paths properly with one homenode" in {
       val visitor = new PathsCounter(10, List(1, 2))
       List(1, 2, 3, 4, 1, 2, 3, 4, 3, 1, 1, 4, 1, 3, 2, 3) foreach { id: Int =>
@@ -42,14 +43,14 @@ class NodeTouristSpec extends Specification {
       }
       val info = visitor.infoAllNodes
 
-      pathMapToSeq(info.get(1)) mustEqual Array((DirectedPath(Array(1)), 5)).toSeq
-      pathMapToSeq(info.get(2)) mustEqual Array((DirectedPath(Array(2)), 3)).toSeq
-      pathMapToSeq(info.get(3)) mustEqual Array(
+      pathMapToSeq(info.get(1)) shouldEqual Array((DirectedPath(Array(1)), 5)).toSeq
+      pathMapToSeq(info.get(2)) shouldEqual Array((DirectedPath(Array(2)), 3)).toSeq
+      pathMapToSeq(info.get(3)) shouldEqual Array(
         (DirectedPath(Array(2, 3)), 3),
         (DirectedPath(Array(2, 3, 4, 3)), 1),
         (DirectedPath(Array(1, 3)), 1)
       ).toSeq
-      pathMapToSeq(info.get(4)) mustEqual Array(
+      pathMapToSeq(info.get(4)) shouldEqual Array(
         (DirectedPath(Array(2, 3, 4)), 2),
         (DirectedPath(Array(1, 4)), 1)
       ).toSeq

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/tourist/NodeTouristSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/tourist/NodeTouristSpec.scala
@@ -11,10 +11,10 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.twitter.cassovary.graph
+package com.twitter.cassovary.graph.tourist
 
-import com.twitter.cassovary.graph.tourist.{VisitsCounter, PathsCounter}
 import com.twitter.cassovary.graph.util.FastUtilConversion
+import com.twitter.cassovary.graph.{DirectedPath, TestNode}
 import it.unimi.dsi.fastutil.ints.Int2IntMap
 import it.unimi.dsi.fastutil.objects.Object2IntMap
 import org.scalatest.WordSpec

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/tourist/NodeTouristSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/tourist/NodeTouristSpec.scala
@@ -31,7 +31,7 @@ class NodeTouristSpec extends WordSpec with ShouldMatchers {
         visitor.visit(testNode(id))
       }
 
-      visitMapToSeq(visitor.infoAllNodes) shouldEqual Array((1, 3), (2, 3), (3, 2), (4, 1)).toSeq
+      visitMapToArray(visitor.infoAllNodes) shouldEqual Array((1, 3), (2, 3), (3, 2), (4, 1))
     }
   }
 
@@ -43,25 +43,25 @@ class NodeTouristSpec extends WordSpec with ShouldMatchers {
       }
       val info = visitor.infoAllNodes
 
-      pathMapToSeq(info.get(1)) shouldEqual Array((DirectedPath(Array(1)), 5)).toSeq
-      pathMapToSeq(info.get(2)) shouldEqual Array((DirectedPath(Array(2)), 3)).toSeq
-      pathMapToSeq(info.get(3)) shouldEqual Array(
+      pathMapToArray(info.get(1)) shouldEqual Array((DirectedPath(Array(1)), 5))
+      pathMapToArray(info.get(2)) shouldEqual Array((DirectedPath(Array(2)), 3))
+      pathMapToArray(info.get(3)) shouldEqual Array(
         (DirectedPath(Array(2, 3)), 3),
         (DirectedPath(Array(2, 3, 4, 3)), 1),
         (DirectedPath(Array(1, 3)), 1)
-      ).toSeq
-      pathMapToSeq(info.get(4)) shouldEqual Array(
+      )
+      pathMapToArray(info.get(4)) shouldEqual Array(
         (DirectedPath(Array(2, 3, 4)), 2),
         (DirectedPath(Array(1, 4)), 1)
-      ).toSeq
+      )
     }
   }
 
-  def pathMapToSeq(map: Object2IntMap[DirectedPath]) = {
-    FastUtilConversion.object2IntMapToArray(map).toSeq
+  def pathMapToArray(map: Object2IntMap[DirectedPath]) = {
+    FastUtilConversion.object2IntMapToArray(map)
   }
 
-  def visitMapToSeq(map: Int2IntMap) = {
-    FastUtilConversion.int2IntMapToArray(map).toSeq
+  def visitMapToArray(map: Int2IntMap) = {
+    FastUtilConversion.int2IntMapToArray(map)
   }
 }

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/tourist/NodeTouristSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/tourist/NodeTouristSpec.scala
@@ -36,7 +36,7 @@ class NodeTouristSpec extends WordSpec with ShouldMatchers {
   }
 
   "PathsCounter" should {
-    "count paths properly with one homenode" in {
+    "count paths properly with 2 home nodes" in {
       val visitor = new PathsCounter(10, List(1, 2))
       List(1, 2, 3, 4, 1, 2, 3, 4, 3, 1, 1, 4, 1, 3, 2, 3) foreach { id: Int =>
         visitor.visit(id)


### PR DESCRIPTION
Here's NodeTouristSpec conversion.  I'm not sure about last commit - removed conversion of Array to Seq everywhere.  It seemed like a rational simplification.