### PR TITLE
GraphUtils migration to ScalaTest

### DIFF
--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/GraphUtils.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/GraphUtils.scala
@@ -24,7 +24,6 @@ import scala.util.Random
 /**
  * This class contains some common graph utilities and convenience functions.
  */
-
 class GraphUtils(val graph: Graph) {
 
   import GraphUtils._


### PR DESCRIPTION
Did an easy migration to ScalaTest. However, the test is incomplete mainly because the point of GraphUtils is not very clear to me. In many cases GraphUtils is only a wrapper for concrete algorithms.