### PR TITLE
Minor improvements to SynchronizedDynamicGraph

### DIFF
--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/SynchronizedDynamicNode.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/SynchronizedDynamicNode.scala
@@ -22,7 +22,9 @@ import scala.collection.mutable.ArrayBuffer
 class SynchronizedDynamicNode(val id: Int) extends DynamicNode {
   protected val inEdges = new ArrayBuffer[Int]
   protected val outEdges = new ArrayBuffer[Int]
-  val DELETED_MARKER = 0
+  val DELETED_MARKER = Integer.MIN_VALUE
+  if (id == DELETED_MARKER)
+    throw new IllegalArgumentException("ID " + DELETED_MARKER + " is not allowed.")
 
   /**
    * Override functions of base class.
@@ -85,6 +87,6 @@ class SynchronizedDynamicNode(val id: Int) extends DynamicNode {
   override def toString = {
     val inNodes = synchronized { inboundNodes.toList }
     val outNodes = synchronized { outboundNodes.toList }
-    "SynchronizedDynamicNode(id=%d, out=%s, in=%s)".format(id, inNodes, outNodes)
+    "SynchronizedDynamicNode(id=%d, out=%s, in=%s)".format(id, outNodes, inNodes)
   }
 }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/SynchronizedDynamicNode.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/SynchronizedDynamicNode.scala
@@ -14,6 +14,7 @@
 package com.twitter.cassovary.graph.node
 
 import scala.collection.mutable.ArrayBuffer
+import SynchronizedDynamicNode.DELETED_MARKER
 
 /**
  * A Node supports add and delete operation on its in/out edges.
@@ -22,19 +23,19 @@ import scala.collection.mutable.ArrayBuffer
 class SynchronizedDynamicNode(val id: Int) extends DynamicNode {
   protected val inEdges = new ArrayBuffer[Int]
   protected val outEdges = new ArrayBuffer[Int]
-  require(id != SynchronizedDynamicNode.DELETED_MARKER,
-    "ID " + SynchronizedDynamicNode.DELETED_MARKER + " is not allowed.")
+  require(id != DELETED_MARKER,
+    "ID " + DELETED_MARKER + " is not allowed.")
 
   /**
    * Override functions of base class.
    */
   def inboundNodes = {
     val array = synchronized { inEdges.toArray }
-    array filter { _ != SynchronizedDynamicNode.DELETED_MARKER}
+    array filter { _ != DELETED_MARKER}
   }
   def outboundNodes = synchronized {
     val array = synchronized { outEdges.toArray }
-    array filter {_ != SynchronizedDynamicNode.DELETED_MARKER}
+    array filter {_ != DELETED_MARKER}
   }
 
   override def equals(other: Any) = {
@@ -78,7 +79,7 @@ class SynchronizedDynamicNode(val id: Int) extends DynamicNode {
     // TODO(taotao): reclaim deleted slots.
     val pos = edges.indexOf(nodeId)
     if (pos >= 0) {
-      edges(pos) = SynchronizedDynamicNode.DELETED_MARKER
+      edges(pos) = DELETED_MARKER
     }
     pos
   }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/SynchronizedDynamicNode.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/SynchronizedDynamicNode.scala
@@ -14,7 +14,6 @@
 package com.twitter.cassovary.graph.node
 
 import scala.collection.mutable.ArrayBuffer
-import SynchronizedDynamicNode.DELETED_MARKER
 
 /**
  * A Node supports add and delete operation on its in/out edges.
@@ -23,8 +22,10 @@ import SynchronizedDynamicNode.DELETED_MARKER
 class SynchronizedDynamicNode(val id: Int) extends DynamicNode {
   protected val inEdges = new ArrayBuffer[Int]
   protected val outEdges = new ArrayBuffer[Int]
-  require(id != DELETED_MARKER,
-    "ID " + DELETED_MARKER + " is not allowed.")
+
+  import SynchronizedDynamicNode.DELETED_MARKER
+  
+  require(id != DELETED_MARKER, "ID " + DELETED_MARKER + " is not allowed.")
 
   /**
    * Override functions of base class.

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/SynchronizedDynamicNode.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/SynchronizedDynamicNode.scala
@@ -22,20 +22,19 @@ import scala.collection.mutable.ArrayBuffer
 class SynchronizedDynamicNode(val id: Int) extends DynamicNode {
   protected val inEdges = new ArrayBuffer[Int]
   protected val outEdges = new ArrayBuffer[Int]
-  val DELETED_MARKER = Integer.MIN_VALUE
-  if (id == DELETED_MARKER)
-    throw new IllegalArgumentException("ID " + DELETED_MARKER + " is not allowed.")
+  require(id != SynchronizedDynamicNode.DELETED_MARKER,
+    "ID " + SynchronizedDynamicNode.DELETED_MARKER + " is not allowed.")
 
   /**
    * Override functions of base class.
    */
   def inboundNodes = {
     val array = synchronized { inEdges.toArray }
-    array filter { _ != DELETED_MARKER}
+    array filter { _ != SynchronizedDynamicNode.DELETED_MARKER}
   }
   def outboundNodes = synchronized {
     val array = synchronized { outEdges.toArray }
-    array filter {_ != DELETED_MARKER}
+    array filter {_ != SynchronizedDynamicNode.DELETED_MARKER}
   }
 
   override def equals(other: Any) = {
@@ -79,7 +78,7 @@ class SynchronizedDynamicNode(val id: Int) extends DynamicNode {
     // TODO(taotao): reclaim deleted slots.
     val pos = edges.indexOf(nodeId)
     if (pos >= 0) {
-      edges(pos) = DELETED_MARKER
+      edges(pos) = SynchronizedDynamicNode.DELETED_MARKER
     }
     pos
   }
@@ -89,4 +88,8 @@ class SynchronizedDynamicNode(val id: Int) extends DynamicNode {
     val outNodes = synchronized { outboundNodes.toList }
     "SynchronizedDynamicNode(id=%d, out=%s, in=%s)".format(id, outNodes, inNodes)
   }
+}
+
+object SynchronizedDynamicNode {
+  val DELETED_MARKER = Integer.MIN_VALUE
 }

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/SynchronizedDynamicGraphSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/SynchronizedDynamicGraphSpec.scala
@@ -47,12 +47,12 @@ class SynchronizedDynamicGraphSpec extends WordSpec with ShouldMatchers {
 
   "Add new edges in OnlyIn graph" in {
     val graph = createTempGraph(StoredGraphDir.OnlyIn)
-    graph.addEdge(1, 2)
-    val node1 = graph.getNodeById(1).get
+    graph.addEdge(0, 1)
+    val node1 = graph.getNodeById(0).get
     node1.inboundNodes.toList shouldEqual List()
     node1.outboundNodes.toList shouldEqual List()
-    val node2 = graph.getNodeById(2).get
-    node2.inboundNodes.toList shouldEqual List(1)
+    val node2 = graph.getNodeById(1).get
+    node2.inboundNodes.toList shouldEqual List(0)
     node2.outboundNodes.toList shouldEqual List()
   }
 

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/node/SynchronizedDynamicNodeSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/node/SynchronizedDynamicNodeSpec.scala
@@ -48,11 +48,9 @@ class SynchronizedDynamicNodeSpec extends WordSpec with ShouldMatchers {
     }
 
     "throw an exception if id is DELETED_MARKER" in {
-      val DELETED_MARKER = fixture(1).DELETED_MARKER
       intercept[IllegalArgumentException] {
-        fixture(DELETED_MARKER)
+        fixture(SynchronizedDynamicNode.DELETED_MARKER)
       }
     }
   }
 }
-

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/node/SynchronizedDynamicNodeSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/node/SynchronizedDynamicNodeSpec.scala
@@ -46,6 +46,13 @@ class SynchronizedDynamicNodeSpec extends WordSpec with ShouldMatchers {
       node.removeOutBoundNode(4)
       node.outboundNodes.toList shouldEqual List(2)
     }
+
+    "throw an exception if id is DELETED_MARKER" in {
+      val DELETED_MARKER = fixture(1).DELETED_MARKER
+      intercept[IllegalArgumentException] {
+        fixture(DELETED_MARKER)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
To get my feet wet contributing to Cassovary I'd like to make two improvements to SynchronizedDynamicGraph:
1. A minor fix in toString (the in and out neighbors had been mislabled)
2. Adding support for node id 0
The justification for the second one is that in another project I wrote a small example graph with node ids 0, 1, and 2, and SynchronizedDynamicGraph silently ignored the edges to node 0, causing strange results that took time to debug (especially given the unexpected toString behavior).

Thanks!