### PR TITLE
Migration from Ostrich to Metrics

### DIFF
--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/bipartite/IterativeLinkAnalyzer.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/bipartite/IterativeLinkAnalyzer.scala
@@ -16,7 +16,7 @@ package com.twitter.cassovary.graph.bipartite
 import com.twitter.cassovary.util.SmallBoundedPriorityQueue
 import com.twitter.cassovary.graph.{GraphUtils, Node}
 import com.twitter.logging.Logger
-import com.twitter.ostrich.stats.Stats
+import com.twitter.finagle.stats.DefaultStatsReceiver
 import scala.collection.mutable
 
 /**
@@ -29,8 +29,8 @@ case class SuppliedNodeInfo(val node: Node, val initialIterationWeight: Double)
 /**
  * Iteratively analyze links in a bipartite graph.
  * @param graphUtils GraphUtils encapsulating the underlying graph
- * @param resetProbLeft reset probability when iterating from left to right
- * @param resetProbRight reset probability when iterating from right to left
+ * @param resetProbOnLeft reset probability when iterating from left to right
+ * @param resetProbOnRight reset probability when iterating from right to left
  * @param numTopContributors The number of contributors (reasons) to be kept for each score
  */
 class IterativeLinkAnalyzer(graphUtils: GraphUtils, resetProbOnLeft: Double,
@@ -38,6 +38,7 @@ class IterativeLinkAnalyzer(graphUtils: GraphUtils, resetProbOnLeft: Double,
 
   private val graph = graphUtils.graph
   private val log = Logger.get
+  private val statsReceier = DefaultStatsReceiver
 
   // keep track of associated info for every node while doing iterations
   case class NodeInfo(val node: Node, val initialIterationWeight: Double, var weight: Double,
@@ -170,9 +171,9 @@ class IterativeLinkAnalyzer(graphUtils: GraphUtils, resetProbOnLeft: Double,
 
     if (sortOutputByScore) {
       //sort output
-      val sortedLeft = Stats.time("bila_sort_left") { sortedListFrom(nodeInfos(0)) }
+      val sortedLeft = statsReceier.time("bila_sort_left") { sortedListFrom(nodeInfos(0)) }
       log.ifDebug { "Finished sorting left" }
-      val sortedRight = Stats.time("bila_sort_right") { sortedListFrom(nodeInfos(1)) }
+      val sortedRight = statsReceier.time("bila_sort_right") { sortedListFrom(nodeInfos(1)) }
       log.ifDebug { "Finished sorting right" }
       (sortedLeft, sortedRight)
     } else {

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/util/ExecutorUtils.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/util/ExecutorUtils.scala
@@ -15,8 +15,8 @@ package com.twitter.cassovary.util
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.twitter.concurrent.AsyncSemaphore
-import com.twitter.ostrich.stats.Stats
 import com.twitter.util.{Future, FuturePool, Duration}
+import com.twitter.finagle.stats.DefaultStatsReceiver
 import java.util.ArrayList
 import java.util.concurrent.{Future => JFuture, _}
 import java.util.{List => JList}
@@ -25,6 +25,8 @@ import java.util.{List => JList}
  * Utility class for unbounded and bounded parallel execution
  */
 object ExecutorUtils {
+
+  private val statsReceiver = DefaultStatsReceiver
 
   private def rejectedExecutionHandlerFactory(name: String,
       handler: => Unit): RejectedExecutionHandler = {
@@ -84,7 +86,7 @@ object ExecutorUtils {
         taskQueue,
         createThreadFactory(name),
         rejectedExecutionHandlerFactory(name, rejectedExecutionHandler))
-    Stats.addGauge(name + "_queue_depth") { taskQueue.size }
+    statsReceiver.addGauge(name + "_queue_depth") { taskQueue.size }
     createPoolStats(name, threadPoolExecutor)
 
     threadPoolExecutor
@@ -95,8 +97,8 @@ object ExecutorUtils {
   }
 
   private def createPoolStats(name: String, threadPoolExecutor: ThreadPoolExecutor): Unit = {
-    Stats.addGauge(name + "_threads_active") { threadPoolExecutor.getActiveCount }
-    Stats.addGauge(name + "_max_threads_active") { threadPoolExecutor.getLargestPoolSize }
+    statsReceiver.addGauge(name + "_threads_active") { threadPoolExecutor.getActiveCount }
+    statsReceiver.addGauge(name + "_max_threads_active") { threadPoolExecutor.getLargestPoolSize }
   }
 
   /**

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -27,7 +27,8 @@ object Cassovary extends Build {
       "com.twitter" %% "ostrich" % "9.1.0",
       util("logging"),
       "org.scalatest" %% "scalatest" % "1.9.2" % "test",
-      "junit" % "junit" % "4.10" % "test"
+      "junit" % "junit" % "4.10" % "test",
+      "com.twitter" %% "twitter-server" % "1.9.0"
     ),
     resolvers += "twitter repo" at "http://maven.twttr.com",
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -24,10 +24,10 @@ object Cassovary extends Build {
       fastUtilsDependency % "provided",
       "org.mockito" % "mockito-all" % "1.8.5" % "test",
       util("core"),
-      "com.twitter" %% "ostrich" % "9.1.0",
       util("logging"),
       "org.scalatest" %% "scalatest" % "1.9.2" % "test",
       "junit" % "junit" % "4.10" % "test",
+      "com.twitter" %% "finagle-stats" % "6.20.0",
       "com.twitter" %% "twitter-server" % "1.9.0"
     ),
     resolvers += "twitter repo" at "http://maven.twttr.com",
@@ -125,8 +125,7 @@ object Cassovary extends Build {
       name := "cassovary-server",
       libraryDependencies ++= Seq(
         fastUtilsDependency,
-        "com.twitter" %% "finagle-http" % "6.20.0",
-        "com.twitter" %% "finagle-ostrich4" % "6.20.0"
+        "com.twitter" %% "finagle-http" % "6.20.0"
       )
   ).dependsOn(cassovaryCore)
 


### PR DESCRIPTION
So, There is two ways of using StatsReceier : 

1. Use DefaultStatsReceiver directly.
2. Pass StatsReceiver while initializing

I have used the first one which I think is better. What are your thoughts? @szymonm @pankajgupta @caniszczyk 

Now, you can use the stats at `localhost:9990/admin/metrics.json?filtered=true` after passing `-com.twitter.finagle.stats.statsFilter="jvm.*,.*\.p90"`

And please tell me what more changes are needed?