### PR TITLE
Update Scala 2.11 version and enable 2.10 cross-publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,14 @@
 language: scala
 sudo: false
+
 scala:
-  - 2.11.4
+  - 2.10.4
+  - 2.11.5
+
+jdk:
+  - openjdk7
+  - oraclejdk7
+  - oraclejdk8
+
+script:
+  - sbt ++$TRAVIS_SCALA_VERSION test

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -36,9 +36,6 @@ object Cassovary extends Build {
     scalacOptions ++= Seq("-encoding", "utf8"),
     scalacOptions += "-deprecation",
 
-    javacOptions ++= Seq("-source", "1.6", "-target", "1.6"),
-    javacOptions in doc := Seq("-source", "1.6"),
-
     fork in run := true,
     javaOptions in run ++= Seq("-server"),
     outputStrategy := Some(StdoutOutput),

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -17,7 +17,8 @@ object Cassovary extends Build {
   val sharedSettings = Seq(
     version := "4.0.0",
     organization := "com.twitter",
-    scalaVersion := "2.11.4",
+    scalaVersion := "2.11.5",
+    crossScalaVersions := Seq("2.10.4", "2.11.5"),
     retrieveManaged := true,
     libraryDependencies ++= Seq(
       "com.google.guava" % "guava" % "16.0.1",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.7


### PR DESCRIPTION
This does a few little clean-up chores: it adds support for cross-publishing for 2.10 (see #126), updates the Travis CI config to test both Scala versions (and multiple JDKs), and adds explicit SBT version configuration for people who aren't using the provided `sbt` script.

Note that I'm not using the provided `sbt` script in the Travis build because of [this issue](https://github.com/travis-ci/travis-ci/issues/3120). When they get that fixed it's probably worth reconsidering which we want to use there.