### PR TITLE
Remove the unnecessary "() =>" in `def iteratorSeq` 

### DIFF
--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/ArrayBasedDynamicDirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/ArrayBasedDynamicDirectedGraph.scala
@@ -29,10 +29,10 @@ class ArrayBasedDynamicDirectedGraph(val storedGraphDir: StoredGraphDir)
 
   private var _nodeCount = 0
 
-  def this(dataIterator: Iterator[NodeIdEdgesMaxId],
+  def this(dataIterable: Iterable[NodeIdEdgesMaxId],
             storedGraphDir: StoredGraphDir) {
     this(storedGraphDir)
-    for (nodeData <- dataIterator) {
+    for (nodeData <- dataIterable) {
       val id = nodeData.id
       getOrCreateNode(id)
       nodeData.edges map getOrCreateNode
@@ -44,9 +44,9 @@ class ArrayBasedDynamicDirectedGraph(val storedGraphDir: StoredGraphDir)
     }
   }
 
-  def this(iteratorSeq: Seq[() => Iterator[NodeIdEdgesMaxId]],
+  def this(iterableSeq: Seq[Iterable[NodeIdEdgesMaxId]],
            storedGraphDir: StoredGraphDir) {
-    this((iteratorSeq.view flatMap { _()}).iterator, storedGraphDir)
+    this(iterableSeq.flatten , storedGraphDir)
   }
 
   /* Returns an option which is non-empty if outbound list for id  is non-null. */

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/ArrayBasedDynamicDirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/ArrayBasedDynamicDirectedGraph.scala
@@ -32,7 +32,7 @@ class ArrayBasedDynamicDirectedGraph(val storedGraphDir: StoredGraphDir)
   def this(dataIterable: Iterable[NodeIdEdgesMaxId],
             storedGraphDir: StoredGraphDir) {
     this(storedGraphDir)
-    for (nodeData <- dataIterable) {
+    for (nodeData <- dataIterable.iterator) {
       val id = nodeData.id
       getOrCreateNode(id)
       nodeData.edges map getOrCreateNode

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/TestGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/TestGraph.scala
@@ -62,28 +62,28 @@ object TestGraphs {
     TestNode(2, Nil, List(1))
     )
 
-  def g3 = ArrayBasedDirectedGraph( () => Seq(
+  def g3 = ArrayBasedDirectedGraph(Seq(
     NodeIdEdgesMaxId(10, Array(11, 12)),
     NodeIdEdgesMaxId(11, Array(12)),
     NodeIdEdgesMaxId(12, Array(11))
-    ).iterator, StoredGraphDir.BothInOut)
+    ), StoredGraphDir.BothInOut)
 
-  def g5 = ArrayBasedDirectedGraph( ()  => Seq(
+  def g5 = ArrayBasedDirectedGraph(Seq(
     NodeIdEdgesMaxId(10, Array(11, 12, 13)),
     NodeIdEdgesMaxId(11, Array(12)),
     NodeIdEdgesMaxId(12, Array(11)),
     NodeIdEdgesMaxId(13, Array(14)),
     NodeIdEdgesMaxId(14, Array())
-    ).iterator, StoredGraphDir.BothInOut)
+    ), StoredGraphDir.BothInOut)
 
-  val nodeSeqIterator = () => Seq(
+  val nodeSeqIterator = Seq(
       NodeIdEdgesMaxId(10, Array(11, 12, 13)),
       NodeIdEdgesMaxId(11, Array(12, 14)),
       NodeIdEdgesMaxId(12, Array(14)),
       NodeIdEdgesMaxId(13, Array(12, 14)),
       NodeIdEdgesMaxId(14, Array(15)),
       NodeIdEdgesMaxId(15, Array(10, 11))
-      ).iterator
+      )
 
   // using testGraph becomes onerous for non-trivial graphs
   def g6 = ArrayBasedDirectedGraph(nodeSeqIterator, StoredGraphDir.BothInOut)
@@ -91,7 +91,7 @@ object TestGraphs {
   def g6_onlyout = ArrayBasedDirectedGraph(nodeSeqIterator, StoredGraphDir.OnlyOut)
   def g6_onlyin = ArrayBasedDirectedGraph(nodeSeqIterator, StoredGraphDir.OnlyIn)
 
-  val nodeSeqIterator2 = () => Seq(
+  val nodeSeqIterator2 = Seq(
       NodeIdEdgesMaxId(10, Array(11, 12, 13)),
       NodeIdEdgesMaxId(11, Array(10, 13, 14)),
       NodeIdEdgesMaxId(12, Array(13, 14)),
@@ -99,7 +99,7 @@ object TestGraphs {
       NodeIdEdgesMaxId(14, Array(10, 11, 15)),
       NodeIdEdgesMaxId(15, Array(10, 11, 16)),
       NodeIdEdgesMaxId(16, Array(15))
-      ).iterator
+      )
   def g7_onlyout = ArrayBasedDirectedGraph(nodeSeqIterator2, StoredGraphDir.OnlyOut)
   def g7_onlyin = ArrayBasedDirectedGraph(nodeSeqIterator2, StoredGraphDir.OnlyIn)
 
@@ -145,7 +145,7 @@ object TestGraphs {
       val edgesFromSource = positiveBits map (x => if (x < source) x else x + 1)
       nodes(source) = NodeIdEdgesMaxId(source, edgesFromSource)
     }
-    ArrayBasedDirectedGraph( () => nodes.iterator, graphDir)
+    ArrayBasedDirectedGraph(nodes, graphDir)
   }
 
   /**
@@ -179,6 +179,6 @@ object TestGraphs {
     val nodesEdges = nodes.indices map { i =>
       NodeIdEdgesMaxId(i, nodes(i).asScala.toArray)
     }
-    ArrayBasedDirectedGraph( () => nodesEdges.iterator, graphDir)
+    ArrayBasedDirectedGraph(nodesEdges, graphDir)
   }
 }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/util/io/GraphReader.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/util/io/GraphReader.scala
@@ -37,9 +37,9 @@ import java.util.concurrent.ExecutorService
  */
 trait GraphReader[T] {
   /**
-   * Should return a sequence of iterators over `NodeIdEdgesMaxId` objects
+   * Should return a sequence of `NodeIdEdgesMaxId` iterables
    */
-  def iteratorSeq: Seq[() => Iterator[NodeIdEdgesMaxId]]
+  def iterableSeq: Seq[Iterable[NodeIdEdgesMaxId]]
 
   /**
    * Define node numberer
@@ -62,7 +62,7 @@ trait GraphReader[T] {
    * Create an `ArrayBasedDirectedGraph`
    */
   def toArrayBasedDirectedGraph() = {
-    ArrayBasedDirectedGraph(iteratorSeq, parallelismLimit, storedGraphDir)
+    ArrayBasedDirectedGraph(iterableSeq, parallelismLimit, storedGraphDir)
   }
 
   /**
@@ -71,13 +71,13 @@ trait GraphReader[T] {
    *                  128 is an arbitrary default
    */
   def toSharedArrayBasedDirectedGraph(numShards: Int = 128) = {
-    SharedArrayBasedDirectedGraph(iteratorSeq, executorService, storedGraphDir, numShards)
+    SharedArrayBasedDirectedGraph(iterableSeq, executorService, storedGraphDir, numShards)
   }
 
   /**
    * Create an `ArrayBasedDynamicDirectedGraph`
    */
   def toArrayBasedDynamicDirectedGraph() = {
-    new ArrayBasedDynamicDirectedGraph(iteratorSeq, storedGraphDir)
+    new ArrayBasedDynamicDirectedGraph(iterableSeq, storedGraphDir)
   }
 }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/util/io/GraphReaderFromDirectory.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/util/io/GraphReaderFromDirectory.scala
@@ -35,12 +35,12 @@ trait GraphReaderFromDirectory[T] extends GraphReader[T] {
   /**
    * Returns a reader for a given file (shard).
    */
-  def oneShardReader(filename : String) : Iterator[NodeIdEdgesMaxId]
+  def oneShardReader(filename : String) : Iterable[NodeIdEdgesMaxId]
 
   /**
-   * Should return a sequence of iterators over NodeIdEdgesMaxId objects
+   * Should return a sequence of `NodeIdEdgesMaxId` iterables
    */
-  def iteratorSeq: Seq[() => Iterator[NodeIdEdgesMaxId]] = {
+  def iterableSeq: Seq[Iterable[NodeIdEdgesMaxId]] = {
     val dir = new File(directory)
     val filesInDir = dir.list()
     if (filesInDir == null) {
@@ -55,8 +55,8 @@ trait GraphReaderFromDirectory[T] extends GraphReader[T] {
         None
       }
     })
-    validFiles.map({ filename =>
-    {() => oneShardReader(directory + "/" + filename)}
-    }).toSeq
+    validFiles.map { filename =>
+      oneShardReader(directory + "/" + filename)
+    }
   }
 }

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/ArrayBasedDynamicDirectedGraphSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/ArrayBasedDynamicDirectedGraphSpec.scala
@@ -1,16 +1,15 @@
 package com.twitter.cassovary.graph
 
-import org.scalatest.WordSpec
+import org.scalatest.{Matchers, WordSpec}
 import com.twitter.cassovary.graph.StoredGraphDir._
-import org.scalatest.matchers.ShouldMatchers
 
-class ArrayBasedDynamicDirectedGraphSpec extends WordSpec with ShouldMatchers with GraphBehaviours {
+class ArrayBasedDynamicDirectedGraphSpec extends WordSpec with Matchers with GraphBehaviours {
   val graphDirections = List(StoredGraphDir.OnlyIn, StoredGraphDir.OnlyOut, StoredGraphDir.BothInOut,
                              StoredGraphDir.Mutual) // Bipartitie is not supported
 
-  def builder(iteratorFunc: () => Iterator[NodeIdEdgesMaxId],
+  def builder(iteratable: Iterable[NodeIdEdgesMaxId],
               storedGraphDir: StoredGraphDir) =
-    new ArrayBasedDynamicDirectedGraph(iteratorFunc(), storedGraphDir)
+    new ArrayBasedDynamicDirectedGraph(iteratable, storedGraphDir)
   verifyGraphBuilding(builder, sampleGraphEdges)
 
   "An ArrayBasedDynamicDirectedGraph" should {

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/GraphBehaviours.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/GraphBehaviours.scala
@@ -108,16 +108,16 @@ trait GraphBehaviours extends Matchers {
 
   // verify a graph constructed from a supplied map of node id -> array of edges (outedges unless
   // OnlyIn direction is to be stored in which case the supplied edges are incoming edges)
-  def verifyGraphBuilding(builder: (() => Iterator[NodeIdEdgesMaxId], StoredGraphDir) => DirectedGraph,
+  def verifyGraphBuilding(builder: (Iterable[NodeIdEdgesMaxId], StoredGraphDir) => DirectedGraph,
                   givenEdges: Map[Int, Array[Int]]): Unit =
   {
     def cross(k: Int, s: Array[Int]) = for (e <- s) yield (e, k)
 
     val allIds: Set[Int] = givenEdges.keys.toSet ++ givenEdges.values.toSet.flatMap { x: Array[Int] => x }
     val noEdges = Map.empty[Int, Array[Int]]
-    def iteratorFunc = () => { givenEdges map { case (k, s) => NodeIdEdgesMaxId(k, s) } toIterator }
+    def iterableSeq = givenEdges map { case (k, s) => NodeIdEdgesMaxId(k, s) }
     for (dir <- List(StoredGraphDir.BothInOut, StoredGraphDir.OnlyOut, StoredGraphDir.OnlyIn)) {
-      val graph = builder(iteratorFunc, dir)
+      val graph = builder(iterableSeq, dir)
       "Graph constructed in direction " + dir should {
         val inEdges: Map[Int, Array[Int]] = dir match {
           case StoredGraphDir.OnlyIn => givenEdges

--- a/cassovary-examples/src/main/java/RandomWalkJava.java
+++ b/cassovary-examples/src/main/java/RandomWalkJava.java
@@ -24,6 +24,7 @@ import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import scala.Tuple2;
 import scala.collection.JavaConverters$;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -89,6 +90,11 @@ public class RandomWalkJava {
 
   @SuppressWarnings("unchecked")
   private static Map<Integer, Integer> scalaIntsMapToJavaMap(scala.collection.Map<Object, Object> map) {
-    return (Map<Integer, Integer>) JavaConverters$.MODULE$.mapAsJavaMapConverter(map);
+    Map<Object, Object> javaMap = JavaConverters$.MODULE$.mapAsJavaMapConverter(map).asJava();
+    HashMap<Integer, Integer> javaIntsMap = new HashMap<>();
+    for(Object key: javaMap.keySet()){
+        javaIntsMap.put((Integer)key, (Integer)javaMap.get(key));
+    }
+    return javaIntsMap;
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -15,7 +15,7 @@ object Cassovary extends Build {
         ExclusionRule(organization = "org.mockito"))
 
   val sharedSettings = Seq(
-    version := "4.0.0",
+    version := "5.0.0",
     organization := "com.twitter",
     scalaVersion := "2.11.5",
     crossScalaVersions := Seq("2.10.4", "2.11.5"),


### PR DESCRIPTION
I made an abstract class as @szymonm said.

```
abstract class NodeStream extends Iterable[NodeIdEdgesMaxId] with Closeable {..}
```
Then, I used it in AdjacencyListGraphReader.scala & ListOfEdgesGraphReader.scala.

I implemened the `close()` method to close the file.

Is this correct? I haven't removed "() => " in `def iteratorSeq`.  I will do it after reviews on this.