### PR TITLE
Undirected Graph Support in Cassovary

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Cassovary is published to maven central with crosspath scala versions 2.10.4 and
 
 To use with sbt, use:
 
-```libraryDependencies += "com.twitter" %% "cassovary-core" % "4.0.0"```
+```libraryDependencies += "com.twitter" %% "cassovary-core" % "5.0.0"```
 
 The last Cassovary version to support scala 2.9 is 3.4.0, and
 support for scala version 2.9.x has been discontinued since.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ To use with sbt, use:
 
 ```libraryDependencies += "com.twitter" %% "cassovary-core" % "5.0.0"```
 
+and
+
+```resolvers += "twitter" at "http://maven.twttr.com"```
+
 The last Cassovary version to support scala 2.9 is 3.4.0, and
 support for scala version 2.9.x has been discontinued since.
 

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/ArrayBasedDirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/ArrayBasedDirectedGraph.scala
@@ -293,10 +293,9 @@ object ArrayBasedDirectedGraph {
           val futures = (nodesOutEdges.iterator ++ Iterator(nodesWithNoOutEdges)).map {
             (nodes: Seq[Node]) => futurePool {
               nodes foreach { node =>
-                val fillingInEdgesNode = node.asInstanceOf[FillingInEdgesBiDirectionalNode]
                 val edgeSize = inEdgesSizes(node.id).intValue()
                 if (edgeSize > 0) {
-                  fillingInEdgesNode.createInEdges(edgeSize)
+                  node.asInstanceOf[FillingInEdgesBiDirectionalNode].createInEdges(edgeSize)
                   // reset inEdgesSizes, and use it as index pointer of
                   // the current insertion place when adding in edges
                   inEdgesSizes(node.id).set(0)

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/ArrayBasedDirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/ArrayBasedDirectedGraph.scala
@@ -69,7 +69,7 @@ object NeighborsSortingStrategy extends Enumeration {
 }
 
 object ArrayBasedDirectedGraph {
-  import com.twitter.cassovary.graph.NeighborsSortingStrategy._
+  import NeighborsSortingStrategy._
 
   def apply(iteratorSeq: Seq[Iterable[NodeIdEdgesMaxId]],
             parallelismLimit: Int,
@@ -295,8 +295,8 @@ object ArrayBasedDirectedGraph {
               nodes foreach { node =>
                 val fillingInEdgesNode = node.asInstanceOf[FillingInEdgesBiDirectionalNode]
                 val edgeSize = inEdgesSizes(node.id).intValue()
-                fillingInEdgesNode.inEdges = new Array[Int](edgeSize)
                 if (edgeSize > 0) {
+                  fillingInEdgesNode.createInEdges(edgeSize)
                   // reset inEdgesSizes, and use it as index pointer of
                   // the current insertion place when adding in edges
                   inEdgesSizes(node.id).set(0)

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/ArrayBasedDirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/ArrayBasedDirectedGraph.scala
@@ -16,9 +16,10 @@ package com.twitter.cassovary.graph
 import com.google.common.annotations.VisibleForTesting
 import com.twitter.cassovary.graph.StoredGraphDir._
 import com.twitter.cassovary.graph.node._
-import com.twitter.cassovary.util.BoundedFuturePool
+import com.twitter.cassovary.util.{SortedArrayOps, BoundedFuturePool}
 import com.twitter.finagle.stats.DefaultStatsReceiver
 import com.twitter.logging.Logger
+import com.twitter.util.Future.when
 import com.twitter.util.{Await, FuturePool, Future}
 import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable
@@ -49,17 +50,43 @@ object NodeIdEdgesMaxId {
 private case class NodesMaxIds(nodesInOnePart: Seq[Node],
                                maxIdInPart: Int, nodeWithOutEdgesMaxIdInPart: Int)
 
+/**
+ * ArrayBasedDirectedGraph can be stored with neighbors sorted or not. Therefore there
+ * are 3 strategies of loading a graph from input:
+ *   `AlreadySorted` - creates a graph with sorted neighbors from sorted input
+ *   `SortWhileReading` - creates a graph with sorted neighbors sorting them
+ *                        while reading
+ *   `LeaveUnsorted` - creates graph with unsorted neighbors (default)
+ */
+object NeighborsSortingStrategy extends Enumeration {
+  type NeighborsSortingStrategy = Value
+
+  val AlreadySorted = Value
+  val SortWhileReading = Value
+  val LeaveUnsorted = Value
+}
+
 object ArrayBasedDirectedGraph {
-  def apply(iterableSeq: Seq[Iterable[NodeIdEdgesMaxId]], parallelismLimit: Int,
-            storedGraphDir: StoredGraphDir):
+  import NeighborsSortingStrategy._
+
+  def apply(iteratorSeq: Seq[Iterable[NodeIdEdgesMaxId]],
+            parallelismLimit: Int,
+            storedGraphDir: StoredGraphDir,
+            neighborsSortingStrategy: NeighborsSortingStrategy = LeaveUnsorted):
   ArrayBasedDirectedGraph = {
-    val constructor = new ArrayBasedDirectedGraphConstructor(iterableSeq, parallelismLimit, storedGraphDir)
+    val constructor = new ArrayBasedDirectedGraphConstructor(iteratorSeq,
+                                                             parallelismLimit,
+                                                             storedGraphDir,
+                                                             neighborsSortingStrategy)
     constructor()
   }
 
   @VisibleForTesting
   def apply(iterable: Iterable[NodeIdEdgesMaxId],
-            storedGraphDir: StoredGraphDir): ArrayBasedDirectedGraph = apply(Seq(iterable), 1, storedGraphDir)
+            storedGraphDir: StoredGraphDir,
+            neighborsSortingStrategy: NeighborsSortingStrategy): ArrayBasedDirectedGraph = {
+    apply(Seq(iterable), 1, storedGraphDir, neighborsSortingStrategy)
+  }
 
   /**
    * Constructs array based directed graph
@@ -67,10 +94,13 @@ object ArrayBasedDirectedGraph {
   private class ArrayBasedDirectedGraphConstructor(
     iterableSeq: Seq[Iterable[NodeIdEdgesMaxId]],
     parallelismLimit: Int,
-    storedGraphDir: StoredGraphDir
+    storedGraphDir: StoredGraphDir,
+    neighborsSortingStrategy: NeighborsSortingStrategy
   ) {
     private lazy val log = Logger.get()
     private val statsReceiver = DefaultStatsReceiver
+
+    private val emptyArray = Array[Int]()
 
     private val futurePool = new BoundedFuturePool(FuturePool.unboundedPool, parallelismLimit)
 
@@ -94,7 +124,7 @@ object ArrayBasedDirectedGraph {
         (table, nodeIdSet) <- markStoredNodes(nodesOutEdges, maxNodeId, storedGraphDir)
         NodesWithNoOutEdgesAndGraphStats(nodesWithNoOutEdges, nodeWithOutEdgesCount, numEdges, numNodes) =
         createNodesWithNoOutEdges(table, nodeIdSet, maxNodeId, storedGraphDir)
-        _ <- Future.when(storedGraphDir == StoredGraphDir.BothInOut) {
+        _ <- when(storedGraphDir == StoredGraphDir.BothInOut) {
           fillMissingInEdges(table, nodesOutEdges, nodesWithNoOutEdges, nodeIdSet, maxNodeId)
         }
       } yield
@@ -148,9 +178,10 @@ object ArrayBasedDirectedGraph {
           id = item.id
           newMaxId = newMaxId max item.maxId
           varNodeWithOutEdgesMaxId = varNodeWithOutEdgesMaxId max item.id
-          val edges = item.edges
-          edgesLength = edges.length
-          val newNode = ArrayBasedDirectedNode(id, edges, storedGraphDir)
+          edgesLength = item.edges.length
+          val edges = if (neighborsSortingStrategy == SortWhileReading) item.edges.sorted else item.edges
+          val newNode = ArrayBasedDirectedNode(id, edges, storedGraphDir,
+            neighborsSortingStrategy != LeaveUnsorted)
           nodes += newNode
         }
         NodesMaxIds(nodes, newMaxId, varNodeWithOutEdgesMaxId)
@@ -224,7 +255,8 @@ object ArrayBasedDirectedGraph {
           if (nodeIdSet(id) == 1) {
             numNodes += 1
             if (table(id) == null) {
-              val node = ArrayBasedDirectedNode(id, ArrayBasedDirectedNode.noNodes, storedGraphDir)
+              val node = ArrayBasedDirectedNode(id, emptyArray, storedGraphDir,
+                neighborsSortingStrategy != LeaveUnsorted)
               table(id) = node
               if (storedGraphDir == StoredGraphDir.BothInOut)
                 nodesWithNoOutEdges += node
@@ -259,14 +291,14 @@ object ArrayBasedDirectedGraph {
           val futures = (nodesOutEdges.iterator ++ Iterator(nodesWithNoOutEdges)).map {
             (nodes: Seq[Node]) => futurePool {
               nodes foreach { node =>
-                val biDirNode = node.asInstanceOf[BiDirectionalNode]
-                val nodeId = biDirNode.id
-                val edgeSize = inEdgesSizes(nodeId).intValue()
-                if (edgeSize > 0)
-                  biDirNode.inEdges = new Array[Int](edgeSize)
-                // reset inEdgesSizes, and use it as index pointer of
-                // the current insertion place when adding in edges
-                inEdgesSizes(nodeId).set(0)
+                val edgeSize = inEdgesSizes(node.id).intValue()
+                if (edgeSize > 0) {
+                  val fillingEdgesNode = new FillingInEdgesBiDirectionalNode(node, edgeSize)
+                  table(node.id) = fillingEdgesNode
+                  // reset inEdgesSizes, and use it as index pointer of
+                  // the current insertion place when adding in edges
+                  inEdgesSizes(node.id).set(0)
+                }
               }
             }
           }.toSeq
@@ -282,8 +314,27 @@ object ArrayBasedDirectedGraph {
               nodes foreach { node =>
                 node.outboundNodes foreach { outEdge =>
                   val index = inEdgesSizes(outEdge).getAndIncrement
-                  table(outEdge).asInstanceOf[BiDirectionalNode].inEdges(index) = node.id
+                  table(outEdge).asInstanceOf[FillingInEdgesBiDirectionalNode].inEdges(index) = node.id
                 }
+              }
+            }
+          }
+          Future.join(futures)
+        }
+      }
+
+      def finishInEdgesFilling(): Future[Unit] = {
+        log.debug("finishing filling")
+        statsReceiver.time("finishing_filling_in_edges") {
+          val futures = nodesOutEdges.map {
+            nodes => futurePool {
+              nodes.foreach {
+                node =>
+                  table(node.id) match {
+                    case fillingInEdgesNode: FillingInEdgesBiDirectionalNode =>
+                      table(node.id) = fillingInEdgesNode.finishingFilling(neighborsSortingStrategy != LeaveUnsorted)
+                    case _ => // no need to finish filling
+                  }
               }
             }
           }
@@ -295,6 +346,7 @@ object ArrayBasedDirectedGraph {
         inEdgesSizes <- findInEdgesSizes(nodesOutEdges, nodeIdSet, numNodes)
         _ <- instantiateInEdges(inEdgesSizes)
         _ <- populateInEdges(inEdgesSizes)
+        _ <- when(neighborsSortingStrategy != LeaveUnsorted) (finishInEdgesFilling())
       } yield ()
     }
 

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/Node.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/Node.scala
@@ -19,7 +19,7 @@ import scala.util.Random
  *   Represents a node in a directed graph.
  */
 trait Node {
-  import GraphDir._
+  import com.twitter.cassovary.graph.GraphDir._
 
   /**
    * The unique id of this node.
@@ -215,6 +215,17 @@ trait Node {
   }
 
   /**
+   * @return Intersection of `dir` neighbors with `nodeIds`.
+   */
+  def intersect(dir: GraphDir, nodeIds: Seq[Int]): Seq[Int] = {
+    intersect(neighborIds(dir), nodeIds)
+  }
+
+  protected def intersect(neighbors: Seq[Int], nodeIds: Seq[Int]): Seq[Int] = {
+    neighbors.intersect(nodeIds)
+  }
+
+  /**
    * the neighbor count in the allowing direction `dir`
    * @param dir the direction (inbound or outbound) that the method is applied to.
    * @return the number of neighbors in the direction of `dir`.
@@ -273,9 +284,18 @@ trait Node {
 
 object Node {
   private lazy val randGen: Random = new Random
-  def apply(nodeId: Int, out: Seq[Int], in: Seq[Int]) = new Node {
-    val id = nodeId
-    def inboundNodes() = in
-    def outboundNodes() = out
+
+  def apply(nodeId: Int, in: Seq[Int], out: Seq[Int]): Node = {
+    new SeqBasedNode(nodeId, in, out)
+  }
+
+  def withSortedNeighbors(nodeId: Int, in: Array[Int], out: Array[Int]) = {
+    new SeqBasedNode(nodeId, in, out) with SortedNeighborsNodeOps
   }
 }
+
+/**
+ * Constructor for a default node with neighbors stored as Seqs.
+ */
+class SeqBasedNode private[graph] (val id: Int, val inboundNodes: Seq[Int], val outboundNodes: Seq[Int])
+  extends Node

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/SortedNeighborsNodeOps.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/SortedNeighborsNodeOps.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.twitter.cassovary.graph
+
+import com.twitter.cassovary.util.SortedArrayOps
+
+/**
+ * This trait designed to be mixed in to `Node` when neighbors of node
+ * are sorted Arrays.
+ */
+trait SortedNeighborsNodeOps {
+  self: Node =>
+
+  override protected def containsNode(nodeIds: Seq[Int], queryNodeId: Int): Boolean = {
+    SortedArrayOps.exists(nodeIds.toArray, queryNodeId)
+  }
+
+  override protected def intersect(neighbors: Seq[Int], nodeIds: Seq[Int]): Seq[Int] = {
+    SortedArrayOps.intersectSorted(neighbors.toArray, nodeIds.toArray)
+  }
+}

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/TestGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/TestGraph.scala
@@ -66,7 +66,7 @@ object TestGraphs {
     NodeIdEdgesMaxId(10, Array(11, 12)),
     NodeIdEdgesMaxId(11, Array(12)),
     NodeIdEdgesMaxId(12, Array(11))
-    ), StoredGraphDir.BothInOut)
+    ), StoredGraphDir.BothInOut, NeighborsSortingStrategy.LeaveUnsorted)
 
   def g5 = ArrayBasedDirectedGraph(Seq(
     NodeIdEdgesMaxId(10, Array(11, 12, 13)),
@@ -74,7 +74,7 @@ object TestGraphs {
     NodeIdEdgesMaxId(12, Array(11)),
     NodeIdEdgesMaxId(13, Array(14)),
     NodeIdEdgesMaxId(14, Array())
-    ), StoredGraphDir.BothInOut)
+    ), StoredGraphDir.BothInOut, NeighborsSortingStrategy.LeaveUnsorted)
 
   val nodeSeqIterator = Seq(
       NodeIdEdgesMaxId(10, Array(11, 12, 13)),
@@ -91,11 +91,15 @@ object TestGraphs {
   ) ++ nodeSeqIterator
 
   // using testGraph becomes onerous for non-trivial graphs
-  def g6 = ArrayBasedDirectedGraph(nodeSeqIterator, StoredGraphDir.BothInOut)
+  def g6 = ArrayBasedDirectedGraph(nodeSeqIterator, StoredGraphDir.BothInOut,
+    NeighborsSortingStrategy.LeaveUnsorted)
 
-  def g6_onlyout = ArrayBasedDirectedGraph(nodeSeqIterator, StoredGraphDir.OnlyOut)
-  def g6_onlyin = ArrayBasedDirectedGraph(nodeSeqIterator, StoredGraphDir.OnlyIn)
-  def g6WithEmptyNodes = ArrayBasedDirectedGraph(nodeSeqIteratorWithEmpty, StoredGraphDir.BothInOut)
+  def g6_onlyout = ArrayBasedDirectedGraph(nodeSeqIterator, StoredGraphDir.OnlyOut,
+    NeighborsSortingStrategy.LeaveUnsorted)
+  def g6_onlyin = ArrayBasedDirectedGraph(nodeSeqIterator, StoredGraphDir.OnlyIn,
+    NeighborsSortingStrategy.LeaveUnsorted)
+  def g6WithEmptyNodes = ArrayBasedDirectedGraph(nodeSeqIteratorWithEmpty, StoredGraphDir.BothInOut,
+    NeighborsSortingStrategy.LeaveUnsorted)
 
   val nodeSeqIterator2 = Seq(
       NodeIdEdgesMaxId(10, Array(11, 12, 13)),
@@ -106,8 +110,10 @@ object TestGraphs {
       NodeIdEdgesMaxId(15, Array(10, 11, 16)),
       NodeIdEdgesMaxId(16, Array(15))
       )
-  def g7_onlyout = ArrayBasedDirectedGraph(nodeSeqIterator2, StoredGraphDir.OnlyOut)
-  def g7_onlyin = ArrayBasedDirectedGraph(nodeSeqIterator2, StoredGraphDir.OnlyIn)
+  def g7_onlyout = ArrayBasedDirectedGraph(nodeSeqIterator2, StoredGraphDir.OnlyOut,
+    NeighborsSortingStrategy.LeaveUnsorted)
+  def g7_onlyin = ArrayBasedDirectedGraph(nodeSeqIterator2, StoredGraphDir.OnlyIn,
+    NeighborsSortingStrategy.LeaveUnsorted)
 
   // a complete graph is where each node follows every other node
   def generateCompleteGraph(numNodes: Int) = {
@@ -151,7 +157,8 @@ object TestGraphs {
       val edgesFromSource = positiveBits map (x => if (x < source) x else x + 1)
       nodes(source) = NodeIdEdgesMaxId(source, edgesFromSource)
     }
-    ArrayBasedDirectedGraph(nodes, graphDir)
+    ArrayBasedDirectedGraph(nodes, graphDir,
+      NeighborsSortingStrategy.LeaveUnsorted)
   }
 
   /**
@@ -185,6 +192,7 @@ object TestGraphs {
     val nodesEdges = nodes.indices map { i =>
       NodeIdEdgesMaxId(i, nodes(i).asScala.toArray)
     }
-    ArrayBasedDirectedGraph(nodesEdges, graphDir)
+    ArrayBasedDirectedGraph(nodesEdges, graphDir,
+      NeighborsSortingStrategy.LeaveUnsorted)
   }
 }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/UndirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/UndirectedGraph.scala
@@ -1,0 +1,26 @@
+/*
+* Copyright 2015 Twitter, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+* file except in compliance with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software distributed
+* under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+* CONDITIONS OF ANY KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations under the License.
+*/
+package com.twitter.cassovary.graph
+
+import com.twitter.cassovary.graph.node.UndirectedNode
+
+/**
+ * A graph where the outbound neighbors of each node equal the inbound neighbors.
+ *
+ */
+trait UndirectedGraph extends DirectedGraph {
+  val storedGraphDir = StoredGraphDir.Mutual
+  def getNodeById(id: Int): Option[UndirectedNode]
+  def iterator: Iterator[UndirectedNode]
+}

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/UndirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/UndirectedGraph.scala
@@ -1,0 +1,29 @@
+package com.twitter.cassovary.graph
+
+import com.twitter.cassovary.graph.StoredGraphDir.StoredGraphDir
+
+/*
+ * A graph where the outbound neighbors of each node equal the inbound neighbors.
+ * Given a DirectedGraph which stores the neighbors of each node (as outbound edges),
+ * this class wraps that graph in an undirected view.
+ */
+
+class UndirectedGraph(outboundGraph: DirectedGraph) extends DirectedGraph {
+  override def getNodeById(id: Int): Option[Node] = outboundGraph.getNodeById(id) map { new UndirectedNode(_)}
+
+  override def iterator: Iterator[Node] = outboundGraph.iterator map { new UndirectedNode(_)}
+
+  override def edgeCount: Long = outboundGraph.edgeCount
+
+  override val storedGraphDir: StoredGraphDir = outboundGraph.storedGraphDir
+
+  override def nodeCount: Int = outboundGraph.nodeCount
+}
+
+class UndirectedNode(outboundNode: Node) extends Node {
+  override def outboundNodes(): Seq[Int] = outboundNode.outboundNodes()
+
+  override def inboundNodes(): Seq[Int] = outboundNode.outboundNodes()
+
+  override val id: Int = outboundNode.id
+}

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/UndirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/UndirectedGraph.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014 Twitter, Inc.
+* Copyright 2015 Twitter, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 * file except in compliance with the License. You may obtain a copy of the License at
@@ -13,29 +13,14 @@
 */
 package com.twitter.cassovary.graph
 
-import com.twitter.cassovary.graph.StoredGraphDir.StoredGraphDir
+import com.twitter.cassovary.graph.node.UndirectedNode
 
-/*
+/**
  * A graph where the outbound neighbors of each node equal the inbound neighbors.
- * Given a DirectedGraph which stores the neighbors of each node (as outbound edges),
- * this class wraps that graph in an undirected view.
+ *
  */
-class UndirectedGraph(outboundGraph: DirectedGraph) extends DirectedGraph {
-  override def getNodeById(id: Int): Option[Node] = outboundGraph.getNodeById(id) map { new UndirectedNode(_)}
-
-  override def iterator: Iterator[Node] = outboundGraph.iterator map { new UndirectedNode(_)}
-
-  override def edgeCount: Long = outboundGraph.edgeCount
-
-  override val storedGraphDir: StoredGraphDir = StoredGraphDir.Mutual
-
-  override def nodeCount: Int = outboundGraph.nodeCount
-}
-
-class UndirectedNode(outboundNode: Node) extends Node {
-  override def outboundNodes(): Seq[Int] = outboundNode.outboundNodes()
-
-  override def inboundNodes(): Seq[Int] = outboundNode.outboundNodes()
-
-  override val id: Int = outboundNode.id
+trait UndirectedGraph extends DirectedGraph {
+  val storedGraphDir = StoredGraphDir.Mutual
+  def getNodeById(id: Int): Option[UndirectedNode]
+  def iterator: Iterator[UndirectedNode]
 }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/UndirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/UndirectedGraph.scala
@@ -1,3 +1,16 @@
+/*
+* Copyright 2014 Twitter, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+* file except in compliance with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software distributed
+* under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+* CONDITIONS OF ANY KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations under the License.
+*/
 package com.twitter.cassovary.graph
 
 import com.twitter.cassovary.graph.StoredGraphDir.StoredGraphDir
@@ -7,7 +20,6 @@ import com.twitter.cassovary.graph.StoredGraphDir.StoredGraphDir
  * Given a DirectedGraph which stores the neighbors of each node (as outbound edges),
  * this class wraps that graph in an undirected view.
  */
-
 class UndirectedGraph(outboundGraph: DirectedGraph) extends DirectedGraph {
   override def getNodeById(id: Int): Option[Node] = outboundGraph.getNodeById(id) map { new UndirectedNode(_)}
 
@@ -15,7 +27,7 @@ class UndirectedGraph(outboundGraph: DirectedGraph) extends DirectedGraph {
 
   override def edgeCount: Long = outboundGraph.edgeCount
 
-  override val storedGraphDir: StoredGraphDir = outboundGraph.storedGraphDir
+  override val storedGraphDir: StoredGraphDir = StoredGraphDir.Mutual
 
   override def nodeCount: Int = outboundGraph.nodeCount
 }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/UndirectedGraphWrapper.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/UndirectedGraphWrapper.scala
@@ -1,0 +1,39 @@
+/*
+* Copyright 2015 Twitter, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+* file except in compliance with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software distributed
+* under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+* CONDITIONS OF ANY KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations under the License.
+*/
+package com.twitter.cassovary.graph
+
+import com.twitter.cassovary.graph.StoredGraphDir.StoredGraphDir
+import com.twitter.cassovary.graph.node.UndirectedNode
+
+/**
+ * An implementation of UndirectedGraph based on an underlying DirectedGraph implementation.
+ * Given a DirectedGraph which stores the neighbors of each node (as outbound edges),
+ * this class wraps that graph in an undirected view.
+ */
+class UndirectedGraphWrapper(outboundGraph: DirectedGraph) extends DirectedGraph {
+  private def wrapNode(node: Node): UndirectedNode =
+    UndirectedNode(node.id, node.outboundNodes())
+
+  override def getNodeById(id: Int): Option[UndirectedNode] =
+    outboundGraph.getNodeById(id) map wrapNode
+
+  override def iterator: Iterator[UndirectedNode] =
+    outboundGraph.iterator map wrapNode
+
+  override def edgeCount: Long = outboundGraph.edgeCount
+
+  override val storedGraphDir: StoredGraphDir = StoredGraphDir.Mutual
+
+  override def nodeCount: Int = outboundGraph.nodeCount
+}

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/UndirectedGraphWrapper.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/UndirectedGraphWrapper.scala
@@ -1,0 +1,39 @@
+/*
+* Copyright 2015 Twitter, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+* file except in compliance with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software distributed
+* under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+* CONDITIONS OF ANY KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations under the License.
+*/
+package com.twitter.cassovary.graph
+
+import com.twitter.cassovary.graph.StoredGraphDir.StoredGraphDir
+import com.twitter.cassovary.graph.node.UndirectedNode
+
+/**
+ * An implementation of UndirectedGraph based on an underlying DirectedGraph implementation.
+ * Given a DirectedGraph which stores the neighbors of each node (as outbound edges),
+ * this class wraps that graph in an undirected view.
+ */
+class UndirectedGraphWrapper(outboundGraph: DirectedGraph) extends DirectedGraph {
+  private def wrapNode(node: Node): UndirectedNode =
+    UndirectedNode(node.id, node.outboundNodes())
+
+  override def getNodeById(id: Int): Option[Node] =
+    outboundGraph.getNodeById(id) map wrapNode
+
+  override def iterator: Iterator[Node] =
+    outboundGraph.iterator map wrapNode
+
+  override def edgeCount: Long = outboundGraph.edgeCount
+
+  override val storedGraphDir: StoredGraphDir = StoredGraphDir.Mutual
+
+  override def nodeCount: Int = outboundGraph.nodeCount
+}

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/ArrayBasedDirectedNode.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/ArrayBasedDirectedNode.scala
@@ -32,7 +32,7 @@ object ArrayBasedDirectedNode {
       case StoredGraphDir.OnlyIn | StoredGraphDir.OnlyOut | StoredGraphDir.Mutual =>
         UniDirectionalNode(nodeId, neighbors, dir, sortedNeighbors)
       case StoredGraphDir.BothInOut =>
-        BiDirectionalNode(nodeId, neighbors, sortedNeighbors)
+        FillingInEdgesBiDirectionalNode(nodeId, neighbors, sortedNeighbors)
     }
   }
 }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/ArrayBasedDirectedNode.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/ArrayBasedDirectedNode.scala
@@ -23,15 +23,16 @@ object ArrayBasedDirectedNode {
    * @param nodeId an id of the node
    * @param neighbors a seq of ids of the neighbors read from file
    * @param dir the stored graph direction (OnlyIn, OnlyOut, BothInOut or Mutual)
+   * @param sortedNeighbors true if the neighbors of the node will be sorted
    *
    * @return a node
    */
-  def apply(nodeId: Int, neighbors: Array[Int], dir: StoredGraphDir) = {
+  def apply(nodeId: Int, neighbors: Seq[Int], dir: StoredGraphDir, sortedNeighbors: Boolean = false) = {
     dir match {
       case StoredGraphDir.OnlyIn | StoredGraphDir.OnlyOut | StoredGraphDir.Mutual =>
-        UniDirectionalNode(nodeId, neighbors, dir)
+        UniDirectionalNode(nodeId, neighbors, dir, sortedNeighbors)
       case StoredGraphDir.BothInOut =>
-        BiDirectionalNode(nodeId, neighbors)
+        BiDirectionalNode(nodeId, neighbors, sortedNeighbors)
     }
   }
 }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/BiDirectionalNode.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/BiDirectionalNode.scala
@@ -30,7 +30,7 @@ case class FillingInEdgesBiDirectionalNode(id: Int, inEdgeSize: Int,
   def this(node: Node, inEdgesSize: Int) =
     this(node.id, inEdgesSize, node.outboundNodes())
 
-  val inEdges: mutable.Seq[Int] = new Array[Int](inEdgeSize)
+  val inEdges = new Array[Int](inEdgeSize)
 
   override def inboundNodes(): Seq[Int] = inEdges
 

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/BiDirectionalNode.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/BiDirectionalNode.scala
@@ -15,7 +15,7 @@ package com.twitter.cassovary.graph.node
 
 import java.{util => jutil}
 
-import com.twitter.cassovary.graph.{SortedNeighborsNodeOps, Node, SeqBasedNode}
+import com.twitter.cassovary.graph.{Node, SeqBasedNode, SortedNeighborsNodeOps}
 import com.twitter.cassovary.util.SharedArraySeq
 
 /**
@@ -24,12 +24,19 @@ import com.twitter.cassovary.util.SharedArraySeq
  */
 trait BiDirectionalNode extends Node
 
-case class FillingInEdgesBiDirectionalNode(id: Int, outboundNodes: Seq[Int])
+class FillingInEdgesBiDirectionalNode(val id: Int, val outboundNodes: Seq[Int])
   extends BiDirectionalNode {
 
-  var inEdges: Array[Int] = null
+  var inEdges: Array[Int] = BiDirectionalNode.noEdges
 
   override def inboundNodes(): Seq[Int] = inEdges
+
+  /**
+   * Creates array of a given size to store incoming edges.
+   */
+  def createInEdges(size: Int): Unit = {
+    inEdges = new Array[Int](size)
+  }
 
   /**
    * Sorts incoming edges.
@@ -39,16 +46,18 @@ case class FillingInEdgesBiDirectionalNode(id: Int, outboundNodes: Seq[Int])
   }
 }
 
-object BiDirectionalNode {
-  val noEdges = Array[Int]()
-
-  def apply(nodeId: Int, out: Seq[Int], sortedNeighbors: Boolean): BiDirectionalNode = {
+object FillingInEdgesBiDirectionalNode {
+  def apply(nodeId: Int, out: Seq[Int], sortedNeighbors: Boolean): FillingInEdgesBiDirectionalNode = {
     if (sortedNeighbors) {
       new FillingInEdgesBiDirectionalNode(nodeId, out) with SortedNeighborsNodeOps
     } else {
       new FillingInEdgesBiDirectionalNode(nodeId, out)
     }
   }
+}
+
+object BiDirectionalNode {
+  val noEdges = Array[Int]()
 
   def apply(nodeId: Int, in: Seq[Int], out: Seq[Int], sortedNeighbors: Boolean = false): BiDirectionalNode = {
     if (sortedNeighbors) {

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/UniDirectionalNode.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/UniDirectionalNode.scala
@@ -23,20 +23,19 @@ import com.twitter.cassovary.util.SharedArraySeq
  */
 trait UniDirectionalNode extends Node
 
-
 /**
  * Factory object for creating uni-directional nodes that uses array as underlying storage
  * for node's edges
  */
 object UniDirectionalNode {
-  def apply(id: Int, inbound: Seq[Int], outbound: Seq[Int]) =
+  def apply(id: Int, inbound: Seq[Int], outbound: Seq[Int]): UniDirectionalNode =
     new UniDirectionalNode {
       override val id: Int = id
       override def inboundNodes(): Seq[Int] = inbound
       override def outboundNodes(): Seq[Int] = outbound
     }
 
-  def apply(nodeId: Int, neighbors: Seq[Int], dir: StoredGraphDir) = {
+  def apply(nodeId: Int, neighbors: Seq[Int], dir: StoredGraphDir): UniDirectionalNode = {
     dir match {
       case StoredGraphDir.OnlyIn =>
         UniDirectionalNode(id=nodeId, inbound=neighbors, outbound=Nil)

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/UniDirectionalNode.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/UniDirectionalNode.scala
@@ -28,37 +28,39 @@ trait UniDirectionalNode extends Node
  * for node's edges
  */
 object UniDirectionalNode {
-  def apply(id: Int, inbound: Seq[Int], outbound: Seq[Int]): UniDirectionalNode =
-    new UniDirectionalNode {
-      override val id: Int = id
-      override def inboundNodes(): Seq[Int] = inbound
-      override def outboundNodes(): Seq[Int] = outbound
-    }
 
-  def apply(nodeId: Int, neighbors: Seq[Int], dir: StoredGraphDir): UniDirectionalNode = {
+  def apply(nodeId: Int, neighbors: Seq[Int], dir: StoredGraphDir) = {
     dir match {
       case StoredGraphDir.OnlyIn =>
-        UniDirectionalNode(id=nodeId, inbound=neighbors, outbound=Nil)
+        new UniDirectionalNode() {
+          override val id = nodeId
+          override def inboundNodes = neighbors
+          override def outboundNodes = Nil
+        }
       case StoredGraphDir.OnlyOut =>
-        UniDirectionalNode(id=nodeId, inbound=Nil, outbound=neighbors)
+        new UniDirectionalNode() {
+          override val id = nodeId
+          override def inboundNodes = Nil
+          override def outboundNodes = neighbors
+        }
       case StoredGraphDir.Mutual =>
-        UndirectedNode(id=nodeId, outbound=neighbors)
+        UndirectedNode(nodeId, neighbors)
     }
   }
 }
 
 /**
- * A node where both directions have the same edges
+ * A node where both directions have the same edges.
  */
 trait UndirectedNode extends UniDirectionalNode {
-  def inboundNodes() = outboundNodes()
+  final def inboundNodes() = outboundNodes()
 }
 
 object UndirectedNode {
-  def apply(id: Int, outbound: Seq[Int]) =
+  def apply(nodeId: Int, outbound: Seq[Int]) =
     new UndirectedNode {
-      override val id: Int = id
-      override def outboundNodes(): Seq[Int] = outbound
+      override val id = nodeId
+      override def outboundNodes() = outbound
     }
 }
 

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/UniDirectionalNode.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/UniDirectionalNode.scala
@@ -13,68 +13,43 @@
  */
 package com.twitter.cassovary.graph.node
 
-import com.twitter.cassovary.graph.{Node, StoredGraphDir}
 import com.twitter.cassovary.graph.StoredGraphDir._
-import com.twitter.cassovary.util.SharedArraySeq
+import com.twitter.cassovary.graph.{SortedNeighborsNodeOps, Node, SeqBasedNode}
+import com.twitter.cassovary.util.{SortedArrayOps, SharedArraySeq}
 
 /**
  * Nodes in the graph that store edges in only one direction (or in the case Mutual Dir graph,
  * both directions have the same edges). Also the edges stored can not be mutated
  */
-abstract class UniDirectionalNode private[graph] (val id: Int) extends Node
+trait UniDirectionalNode extends Node
 
 /**
  * Factory object for creating uni-directional nodes that uses array as underlying storage
  * for node's edges
  */
 object UniDirectionalNode {
-
-  def apply(nodeId: Int, neighbors: Array[Int], dir: StoredGraphDir) = {
-    dir match {
-      case StoredGraphDir.OnlyIn =>
-        new UniDirectionalNode(nodeId) {
-          def inboundNodes = neighbors
-          def outboundNodes = Nil
-        }
-      case StoredGraphDir.OnlyOut =>
-        new UniDirectionalNode(nodeId) {
-          def inboundNodes = Nil
-          def outboundNodes = neighbors
-        }
-      case StoredGraphDir.Mutual =>
-        new UniDirectionalNode(nodeId) {
-          def inboundNodes = neighbors
-          def outboundNodes = neighbors
-        }
+  def apply(nodeId: Int, neighbors: Seq[Int], dir: StoredGraphDir, sortedNeighbors: Boolean = false) = {
+    val in = if (dir == OnlyOut) Nil else neighbors
+    val out = if (dir == OnlyIn) Nil else neighbors
+    if (sortedNeighbors) {
+      new SeqBasedNode(nodeId, in, out) with UniDirectionalNode with SortedNeighborsNodeOps
+    } else {
+      new SeqBasedNode(nodeId, in, out) with UniDirectionalNode
     }
   }
 }
 
 /**
  * Factory object for creating uni-directional nodes that uses shared array as underlying storage
- * for node's edges, * i.e. multiple nodes share a sharded two-dimensional array
+ * for node's edges, * i.e. multiple nodes share a shared two-dimensional array
  * object to hold its edges
  */
 object SharedArrayBasedUniDirectionalNode {
-
   def apply(nodeId: Int, edgeArrOffset: Int, edgeArrLen: Int, sharedArray: Array[Array[Int]],
-      dir: StoredGraphDir) = {
-    dir match {
-      case StoredGraphDir.OnlyIn =>
-        new UniDirectionalNode(nodeId) {
-          def inboundNodes = new SharedArraySeq(nodeId, sharedArray, edgeArrOffset, edgeArrLen)
-          def outboundNodes = Nil
-        }
-      case StoredGraphDir.OnlyOut =>
-        new UniDirectionalNode(nodeId) {
-          def inboundNodes = Nil
-          def outboundNodes = new SharedArraySeq(nodeId, sharedArray, edgeArrOffset, edgeArrLen)
-        }
-      case StoredGraphDir.Mutual =>
-        new UniDirectionalNode(nodeId) {
-          def inboundNodes = new SharedArraySeq(nodeId, sharedArray, edgeArrOffset, edgeArrLen)
-          def outboundNodes = new SharedArraySeq(nodeId, sharedArray, edgeArrOffset, edgeArrLen)
-        }
-    }
+            dir: StoredGraphDir) = {
+    val neighbors = new SharedArraySeq(nodeId, sharedArray, edgeArrOffset, edgeArrLen)
+    new SeqBasedNode(nodeId,
+      if (dir == OnlyOut) Nil else neighbors,
+      if (dir == OnlyIn) Nil else neighbors) with UniDirectionalNode
   }
 }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/UniDirectionalNode.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/node/UniDirectionalNode.scala
@@ -40,11 +40,27 @@ object UniDirectionalNode {
 }
 
 /**
+ * A node where both directions have the same edges.
+ */
+trait UndirectedNode extends UniDirectionalNode {
+  final def inboundNodes() = outboundNodes()
+}
+
+object UndirectedNode {
+  def apply(nodeId: Int, outbound: Seq[Int]) =
+    new UndirectedNode {
+      override val id = nodeId
+      override def outboundNodes() = outbound
+    }
+}
+
+/**
  * Factory object for creating uni-directional nodes that uses shared array as underlying storage
  * for node's edges, * i.e. multiple nodes share a shared two-dimensional array
  * object to hold its edges
  */
 object SharedArrayBasedUniDirectionalNode {
+
   def apply(nodeId: Int, edgeArrOffset: Int, edgeArrLen: Int, sharedArray: Array[Array[Int]],
             dir: StoredGraphDir) = {
     val neighbors = new SharedArraySeq(nodeId, sharedArray, edgeArrOffset, edgeArrLen)

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/util/SortedArrayOps.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/util/SortedArrayOps.scala
@@ -1,0 +1,92 @@
+package com.twitter.cassovary.util
+
+import java.{util => jutil}
+
+object SortedArrayOps {
+  /**
+   * @return true if `elem` is in the `array`.
+   *
+   * Assumes that the collection is sorted. Does not use built-in Scala's
+   * searching methods to avoid boxing/unboxing.
+   */
+  def exists(array: Array[Int], elem: Int): Boolean = {
+    jutil.Arrays.binarySearch(array, elem) match {
+      case idx if idx < 0 => false
+      case idx => true
+    }
+  }
+
+  /**
+   * Linear intersection of two sorted arrays.
+   */
+  def intersectSorted(array: Array[Int], that: Array[Int]): Array[Int] = {
+    val intersection = Array.ofDim[Int](math.min(array.length, that.length))
+    var intersectionIdx = 0
+    var arrayIdx = 0
+    var thatIdx = 0
+
+    while (arrayIdx < array.length && thatIdx < that.length) {
+      if (array(arrayIdx) == that(thatIdx)) {
+        intersection(intersectionIdx) = array(arrayIdx)
+        intersectionIdx += 1
+        arrayIdx += 1
+        thatIdx += 1
+      } else if (array(arrayIdx) < that(thatIdx)) {
+        arrayIdx += 1
+      } else {
+        thatIdx += 1
+      }
+    }
+
+    slice(intersection, 0, intersectionIdx)
+  }
+
+  /**
+   * Linear union of two sorted arrays.
+   *
+   * @return A sorted array containing only once each element
+   *         that wast in either of two arrays.
+   */
+  def unionSorted(thisA: Array[Int], that: Array[Int]): Array[Int] = {
+    val union = Array.ofDim[Int](thisA.length + that.length)
+    var resultIdx = 0
+    var thisIdx = 0
+    var thatIdx = 0
+
+    @inline def putInDest(x: Int): Unit = {
+      union(resultIdx) = x
+      resultIdx += 1
+    }
+
+    while (thisIdx < thisA.length || thatIdx < that.length) {
+      if (thisIdx == thisA.length) {
+        putInDest(that(thatIdx))
+        thatIdx += 1
+      } else if (thatIdx == that.length) {
+        putInDest(thisA(thisIdx))
+        thisIdx += 1
+      } else {
+        if (thisA(thisIdx) == that(thatIdx)) {
+          putInDest(thisA(thisIdx))
+          thisIdx += 1
+          thatIdx += 1 // ignoring duplicates
+        } else if (thisA(thisIdx) < that(thatIdx)) {
+          putInDest(thisA(thisIdx))
+          thisIdx += 1
+        } else {
+          putInDest(that(thatIdx))
+          thatIdx += 1
+        }
+      }
+    }
+
+    slice(union, 0, resultIdx)
+  }
+
+  @inline def slice(a: Array[Int], from: Int, len: Int): Array[Int] = {
+    val result = Array.ofDim[Int](len)
+    Array.copy(a, from, result, 0, len)
+    result
+  }
+}
+

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/ArrayBasedDirectedGraphSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/ArrayBasedDirectedGraphSpec.scala
@@ -16,5 +16,52 @@ package com.twitter.cassovary.graph
 import org.scalatest.WordSpec
 
 class ArrayBasedDirectedGraphSpec extends WordSpec with GraphBehaviours {
-    verifyGraphBuilding(ArrayBasedDirectedGraph.apply, sampleGraphEdges)
+  verifyGraphBuilding(ArrayBasedDirectedGraph.apply(_, _, NeighborsSortingStrategy.LeaveUnsorted),
+    sampleGraphEdges)
+
+  "ArrayBasedDirectedGraph" when {
+    "reading neighbors without sorting" should {
+      val graph = ArrayBasedDirectedGraph.apply(
+        Iterable(
+          NodeIdEdgesMaxId(1, Array(2, 3)),
+          NodeIdEdgesMaxId(2, Array(3, 1)),
+          NodeIdEdgesMaxId(3, Array(1, 2))), StoredGraphDir.BothInOut,
+        NeighborsSortingStrategy.LeaveUnsorted)
+
+      verifyInOutEdges(graph, 3,
+        Map(1 -> Seq(2, 3), 2 -> Seq(3, 1), 3 -> Seq(1, 2)),
+        Map(1 -> Seq(2, 3), 2 -> Seq(1, 3), 3 -> Seq(1, 2)),
+        checkOrdering = true)
+    }
+
+    "reading sorted neighbors and returning graph with sorted neighbors" should {
+      val graph = ArrayBasedDirectedGraph.apply(
+        Iterable(
+          NodeIdEdgesMaxId(3, Array(1, 2)),
+          NodeIdEdgesMaxId(1, Array(2, 3)),
+          NodeIdEdgesMaxId(2, Array(1, 3))
+        ), StoredGraphDir.BothInOut,
+        NeighborsSortingStrategy.AlreadySorted)
+
+      verifyInOutEdges(graph, 3,
+        Map(1 -> Seq(2, 3), 2 -> Seq(1, 3), 3 -> Seq(1, 2)),
+        Map(1 -> Seq(2, 3), 2 -> Seq(1, 3), 3 -> Seq(1, 2)),
+        checkOrdering = true)
+    }
+
+    "sorting neighbors while reading" should {
+      val graph = ArrayBasedDirectedGraph.apply(
+        Iterable(
+          NodeIdEdgesMaxId(3, Array(2, 1)),
+          NodeIdEdgesMaxId(1, Array(3, 2)),
+          NodeIdEdgesMaxId(2, Array(3, 1))
+        ), StoredGraphDir.BothInOut,
+        NeighborsSortingStrategy.SortWhileReading)
+
+      verifyInOutEdges(graph, 3,
+        Map(1 -> Seq(2, 3), 2 -> Seq(1, 3), 3 -> Seq(1, 2)),
+        Map(1 -> Seq(2, 3), 2 -> Seq(1, 3), 3 -> Seq(1, 2)),
+        checkOrdering = true)
+    }
+  }
 }

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/NodeSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/NodeSpec.scala
@@ -126,4 +126,26 @@ class NodeSpec extends WordSpec with Matchers {
       node.randomNeighborSet(4, GraphDir.OutDir)(0) shouldEqual 3
     }
   }
+
+  "A node with sorted neighbors" should {
+    "allow linear intersection of neighbors with other node" in {
+      val node1 = new SeqBasedNode(0, Array(1, 2), Array(4, 6))
+        with SortedNeighborsNodeOps
+
+      val node2 = new SeqBasedNode(0, Array(3), Array(4, 6))
+        with SortedNeighborsNodeOps
+
+      node1.intersect(GraphDir.InDir, node2.inboundNodes) should be (Seq())
+      node1.intersect(GraphDir.OutDir, node2.outboundNodes) should be (Seq(4, 6))
+    }
+
+    "allow logarithmic membership checking" in {
+      val node = new SeqBasedNode(0, Array(1, 2, 3), Array(4, 5, 6)) with SortedNeighborsNodeOps
+      node.isNeighbor(GraphDir.InDir, 1) should be (true)
+      node.isNeighbor(GraphDir.InDir, 4) should be (false)
+
+      node.isNeighbor(GraphDir.OutDir, 1) should be (false)
+      node.isNeighbor(GraphDir.OutDir, 4) should be (true)
+    }
+  }
 }

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/node/ArrayBasedDirectedNodeSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/node/ArrayBasedDirectedNodeSpec.scala
@@ -20,6 +20,9 @@ class ArrayBasedDirectedNodeSpec extends NodeBehaviors {
   val actualOut = ArrayBasedDirectedNode(nodeId, neighbors, StoredGraphDir.OnlyOut)
   val actualMutual = ArrayBasedDirectedNode(nodeId, neighbors, StoredGraphDir.Mutual)
   val actualBoth = ArrayBasedDirectedNode(nodeId, neighbors, StoredGraphDir.BothInOut)
-  actualBoth.asInstanceOf[BiDirectionalNode].inEdges = inEdges
-  correctlyConstructNodes(actualIn, actualOut, actualMutual, actualBoth)
+  val fillingInEdgesNode = new FillingInEdgesBiDirectionalNode(actualBoth, inEdges.size)
+  (0 until inEdges.size).foreach {
+    i => fillingInEdgesNode.inEdges(i) = inEdges(i)
+  }
+  correctlyConstructNodes(actualIn, actualOut, actualMutual, fillingInEdgesNode.finishingFilling(false))
 }

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/node/ArrayBasedDirectedNodeSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/node/ArrayBasedDirectedNodeSpec.scala
@@ -20,9 +20,6 @@ class ArrayBasedDirectedNodeSpec extends NodeBehaviors {
   val actualOut = ArrayBasedDirectedNode(nodeId, neighbors, StoredGraphDir.OnlyOut)
   val actualMutual = ArrayBasedDirectedNode(nodeId, neighbors, StoredGraphDir.Mutual)
   val actualBoth = ArrayBasedDirectedNode(nodeId, neighbors, StoredGraphDir.BothInOut)
-  val fillingInEdgesNode = new FillingInEdgesBiDirectionalNode(actualBoth, inEdges.size)
-  (0 until inEdges.size).foreach {
-    i => fillingInEdgesNode.inEdges(i) = inEdges(i)
-  }
-  correctlyConstructNodes(actualIn, actualOut, actualMutual, fillingInEdgesNode.finishingFilling(false))
+  actualBoth.asInstanceOf[FillingInEdgesBiDirectionalNode].inEdges = inEdges
+  correctlyConstructNodes(actualIn, actualOut, actualMutual, actualBoth)
 }

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/node/NodeBehaviors.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/node/NodeBehaviors.scala
@@ -24,9 +24,9 @@ trait NodeBehaviors extends WordSpec with Matchers {
   def correctlyConstructNodes(actualOnlyIn: Node, actualOnlyOut: Node, actualMutual: Node,
                               actualBoth: Node): Unit = {
     "construct uni-directional nodes correctly" in {
-      val onlyInNode = Node(nodeId, out = Nil, neighbors)
-      val onlyOutNode = Node(nodeId, out = neighbors, Nil)
-      val mutualNode = Node(nodeId, out = neighbors, neighbors)
+      val onlyInNode = Node(nodeId, neighbors, out = Nil)
+      val onlyOutNode = Node(nodeId, Nil, out = neighbors)
+      val mutualNode = Node(nodeId, neighbors, out = neighbors)
       actualOnlyIn should deepEquals(onlyInNode)
       actualOnlyOut should deepEquals(onlyOutNode)
       actualMutual should deepEquals(mutualNode)

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/util/SortedArrayOpsSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/util/SortedArrayOpsSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.twitter.cassovary.util
+
+import org.scalatest.{Matchers, WordSpec}
+
+class SortedArrayOpsSpec extends WordSpec with Matchers {
+  "SortedArrayWrapper" should {
+    "check if element exists in the array" when {
+      "empty array" in {
+        SortedArrayOps.exists(Array[Int](), 4) should be (false)
+      }
+      "array with 1 element" in {
+        SortedArrayOps.exists(Array(1), 4) should be (false)
+        SortedArrayOps.exists(Array(4), 4) should be (true)
+      }
+      "array with few elements" in {
+        SortedArrayOps.exists(Array(1,2,3,4), 4) should be (true)
+        SortedArrayOps.exists(Array(1,2,3,4), 5) should be (false)
+      }
+    }
+
+    "compute an intersection of two arrays" when {
+      "first of the arrays in empty" in {
+        SortedArrayOps.intersectSorted(Array(), Array(1, 2, 3, 4)) should be (Array())
+      }
+
+      "second of the arrays in empty" in {
+        SortedArrayOps.intersectSorted(Array(1, 2, 3, 4), Array()) should be (Array())
+      }
+
+      "arrays don't contain duplicates" in {
+        SortedArrayOps.intersectSorted(Array(2, 3), Array(1, 4)) should be (Array())
+      }
+
+      "arrays contain duplicates" in {
+        SortedArrayOps.intersectSorted(Array(2, 3), Array(1, 2, 3, 4)) should be (Array(2, 3))
+      }
+    }
+    "compute a union of two arrays" when {
+      "first is empty" in {
+        SortedArrayOps.unionSorted(Array(), Array(1, 2, 3, 4)) should be (Array(1, 2, 3, 4))
+      }
+      "second is empty" in {
+        SortedArrayOps.unionSorted(Array(1, 2, 3, 4), Array()) should be (Array(1, 2, 3, 4))
+      }
+
+      "arrays don't contain duplicates" in {
+        SortedArrayOps.unionSorted(Array(2, 3), Array(1, 4)) should be (Array(1, 2, 3, 4))
+      }
+
+      "arrays contain duplicates" in {
+        SortedArrayOps.unionSorted(Array(2, 3), Array(1, 2, 4)) should be (Array(1, 2, 3, 4))
+      }
+    }
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -28,6 +28,7 @@ object Cassovary extends Build {
       util("logging"),
       "org.scalatest" %% "scalatest" % "2.2.3" % "test",
       "junit" % "junit" % "4.10" % "test",
+      "com.twitter.common" % "metrics" % "0.0.29",
       "com.twitter" %% "finagle-stats" % "6.24.0"
     ),
     resolvers += "twitter repo" at "http://maven.twttr.com",


### PR DESCRIPTION
Related to https://github.com/twitter/cassovary/issues/140
The idea of this wrapper is that each graph implementation shouldn't need custom code for `StoredGraphDir.Mutual`.  We can write a single wrapper which works with any graph implementation.
Here is an initial undirected graph class.  If this looks good, I can add a test and support for mutable undirected graphs to this pull request.
@pankajgupta 
