### PR TITLE
Closeness centrality

### DIFF
--- a/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/centrality/AbstractCentrality.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/centrality/AbstractCentrality.scala
@@ -17,7 +17,7 @@ import collection.immutable
 import com.twitter.cassovary.graph.{Node, DirectedGraph}
 
 /**
- * Centrality algorithm abstraction that requires a directed graph {@code graph} be passed upon
+ * Centrality algorithm abstraction that requires a directed graph (``graph``) be passed upon
  * instantiation.
  * {@note The centrality values are stored in an internal array indexed by node's id. Hence, do not use for graphs with very large ids.}
  */
@@ -25,6 +25,7 @@ abstract class AbstractCentrality(graph: DirectedGraph) extends Centrality {
 
   protected val centralityValues = new Array[Double](graph.maxNodeId + 1)
 
+  _recalc()
   /**
    * Get the specified node's centrality value
    * @param n Node
@@ -32,9 +33,14 @@ abstract class AbstractCentrality(graph: DirectedGraph) extends Centrality {
    */
   def apply(n: Node): Double = centralityValues(n.id)
 
+  protected def _recalc(): Unit
+
   /**
    * Run the centrality calculation and update {@code centralityValues}
    * @return The centrality values of the graph
    */
-  def recalculate(): immutable.IndexedSeq[Double]
+  def recalculate(): immutable.IndexedSeq[Double] = {
+    _recalc()
+    centralityValues.toIndexedSeq
+  }
 }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/centrality/ClosenessCentrality.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/centrality/ClosenessCentrality.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.twitter.cassovary.algorithms.centrality
+
+import com.twitter.cassovary.graph.{GraphDir, BreadthFirstTraverser, Walk, DirectedGraph}
+
+/**
+ * Calculate the closeness centrality of ``graph``
+ * @param normalize Normalize by the ratio of number of connections to other nodes
+ *                  and the number of nodes in the graph
+ */
+class ClosenessCentrality(graph: DirectedGraph, normalize: Boolean = true) extends AbstractCentrality(graph) {
+
+  def _recalc(): Unit = {
+    graph foreach { node =>
+      val bfs = new BreadthFirstTraverser(graph, GraphDir.OutDir, Seq(node.id), Walk.Limits())
+      val (sum, reachableNodes) = bfs.foldLeft((0.0, 0.0)) {
+        case ((partialSum, partialCount), a) => (partialSum + bfs.depth(a.id).get, partialCount + 1)
+      }
+      centralityValues(node.id) = if (sum > 0 && graph.nodeCount > 1) {
+          val numerator = reachableNodes - 1
+          val denom = if (normalize) (graph.nodeCount - 1) / (reachableNodes - 1) else 1
+          numerator / (denom * sum)
+      }
+      else 0.0
+    }
+  }
+}

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/centrality/DegreeCentrality.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/centrality/DegreeCentrality.scala
@@ -13,13 +13,12 @@
  */
 package com.twitter.cassovary.algorithms.centrality
 
-import collection.immutable
 import com.twitter.cassovary.graph.DirectedGraph
 import com.twitter.cassovary.graph.GraphDir.GraphDir
 
 /**
  * Calculate the degree centrality for a specific graph and direction.  If normalization
- * is {@code true} then divide each node's degree centrality by the maximum number
+ * is ``true`` then divide each node's degree centrality by the maximum number
  * of possible connections within the graph.
  * @param graph The graph object on which calculate the degree centrality
  * @param dir The direction of the edges to include in the degree centrality calculation.
@@ -27,11 +26,8 @@ import com.twitter.cassovary.graph.GraphDir.GraphDir
  */
 class DegreeCentrality(graph: DirectedGraph, dir: GraphDir, normalize: Boolean = true) extends AbstractCentrality(graph) {
 
-  recalculate()
-
-  def recalculate(): immutable.IndexedSeq[Double] = {
+  def _recalc(): Unit = {
     val denom = if (normalize) graph.nodeCount - 1 else 1.0
     graph foreach { node => centralityValues(node.id) = node.neighborCount(dir) / denom }
-    centralityValues.toIndexedSeq
   }
 }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/Traverser.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/Traverser.scala
@@ -38,7 +38,7 @@ trait Traverser extends Iterator[Node] { self =>
 trait BoundedIterator[T] extends Iterator[T] {
   /**
    * @return If option is defined, it is the maximal number of elements the iterator returns.
-   *         If is `None`, the iteratator is not bounded.
+   *         If is `None`, the iterator is not bounded.
    */
   def maxSteps: Option[Long]
 

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/algorithms/centrality/ClosenessCentralitySpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/algorithms/centrality/ClosenessCentralitySpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.twitter.cassovary.algorithms.centrality
+
+import com.twitter.cassovary.graph.TestGraphs
+import org.scalatest.{WordSpec, Matchers}
+
+class ClosenessCentralitySpec extends WordSpec with Matchers {
+  lazy val graph = TestGraphs.g6WithEmptyNodes
+
+  "Closeness centrality" should {
+
+    "return proper values when unnormalized" in {
+      val cc = new ClosenessCentrality(graph, normalize = false)
+
+      cc(graph.getNodeById(0).get)  shouldEqual 0.0
+      cc(graph.getNodeById(1).get)  shouldEqual 0.0
+      cc(graph.getNodeById(10).get) should be(0.625 +- .005)
+      cc(graph.getNodeById(11).get) should be(0.455 +- .005)
+      cc(graph.getNodeById(12).get) should be(0.385 +- .005)
+      cc(graph.getNodeById(13).get) should be(0.500 +- .005)
+      cc(graph.getNodeById(14).get) should be(0.455 +- .005)
+      cc(graph.getNodeById(15).get) should be(0.625 +- .005)
+    }
+
+    "return proper values when normalized" in {
+      val cc = new ClosenessCentrality(graph, normalize=true)
+      val centrality = cc.recalculate()
+
+      cc(graph.getNodeById(0).get)  shouldEqual 0.0
+      cc(graph.getNodeById(1).get)  shouldEqual 0.0
+      cc(graph.getNodeById(10).get) should be (0.446 +- .005)
+      cc(graph.getNodeById(11).get) should be (0.325 +- .005)
+      cc(graph.getNodeById(12).get) should be (0.275 +- .005)
+      cc(graph.getNodeById(13).get) should be (0.357 +- .005)
+      cc(graph.getNodeById(14).get) should be (0.324 +- .005)
+      cc(graph.getNodeById(15).get) should be (0.446 +- .005)
+    }
+  }
+}


### PR DESCRIPTION
This is the next pr in line for adding more algorithms to cassovary.  This one addresses closeness centrality and was adopted from and checked against this [library](http://networkx.github.io/documentation/networkx-1.9.1/_modules/networkx/algorithms/centrality/closeness.html#closeness_centrality).

AbstractCentrality was slightly refactored to reduce code redundancy that become apparent after adding an additional centrality algorithm.  Tests were also added. 