### PR TITLE
Bug fix in mutable graph and edge reader

### DIFF
--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/ArrayBasedDirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/ArrayBasedDirectedGraph.scala
@@ -37,7 +37,7 @@ import scala.collection.mutable
  * This case class holds a node's id, all its out edges, and the max
  * id of itself and ids of nodes in its out edges
  */
-case class NodeIdEdgesMaxId(val id: Int, val edges: Array[Int], val maxId: Int)
+case class NodeIdEdgesMaxId(id: Int, edges: Array[Int], maxId: Int)
 
 object NodeIdEdgesMaxId {
   def apply(id: Int, edges: Array[Int]) =

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/ArrayBasedDirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/ArrayBasedDirectedGraph.scala
@@ -37,7 +37,7 @@ import scala.collection.mutable
  * This case class holds a node's id, all its out edges, and the max
  * id of itself and ids of nodes in its out edges
  */
-case class NodeIdEdgesMaxId(var id: Int, var edges: Array[Int], var maxId: Int)
+case class NodeIdEdgesMaxId(val id: Int, val edges: Array[Int], val maxId: Int)
 
 object NodeIdEdgesMaxId {
   def apply(id: Int, edges: Array[Int]) =

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/ArrayBasedDynamicDirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/ArrayBasedDynamicDirectedGraph.scala
@@ -46,7 +46,8 @@ class ArrayBasedDynamicDirectedGraph(val storedGraphDir: StoredGraphDir)
 
   def this(iterableSeq: Seq[Iterable[NodeIdEdgesMaxId]],
            storedGraphDir: StoredGraphDir) {
-    this(iterableSeq.flatten , storedGraphDir)
+    // Use view to avoid eagerly reading all edges into memory
+    this(iterableSeq.view.flatten.toIterable, storedGraphDir)
   }
 
   /* Returns an option which is non-empty if outbound list for id  is non-null. */

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/util/io/AdjacencyListGraphReader.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/util/io/AdjacencyListGraphReader.scala
@@ -82,7 +82,6 @@ class AdjacencyListGraphReader[T] (
       private val src = Source.fromFile(filename)
       private val lines = src.getLines()
         .map{x => {lastLineParsed += 1; x}}
-      private val holder = NodeIdEdgesMaxId(-1, null, -1)
 
       override def hasNext: Boolean = {
         val isNotLastLine = lines.hasNext
@@ -110,10 +109,7 @@ class AdjacencyListGraphReader[T] (
             i += 1
           }
 
-          holder.id = internalNodeId
-          holder.edges = outEdgesArr
-          holder.maxId = newMaxId
-          holder
+          NodeIdEdgesMaxId(internalNodeId, outEdgesArr, newMaxId)
         } catch {
           case NonFatal(exc) =>
             throw new IOException("Parsing failed near line: %d in %s"

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/util/io/ListOfEdgesGraphReader.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/util/io/ListOfEdgesGraphReader.scala
@@ -70,7 +70,6 @@ class ListOfEdgesGraphReader[T](
 
     override def iterator = new Iterator[NodeIdEdgesMaxId] {
 
-      private val holder = NodeIdEdgesMaxId(-1, null, -1)
       var lastLineParsed = 0
 
       def readEdgesBySource(): (Int2ObjectMap[ArrayBuffer[Int]], Int2IntArrayMap) = {
@@ -120,10 +119,10 @@ class ListOfEdgesGraphReader[T](
       override def next(): NodeIdEdgesMaxId = {
         try {
           val elem = edgesIterator.next()
-          holder.id = elem.getKey
-          holder.edges = elem.getValue.toArray
-          holder.maxId = nodeMaxOutEdgeId.get(elem.getKey)
-          holder
+          NodeIdEdgesMaxId(
+            id=elem.getKey,
+            edges=elem.getValue.toArray,
+            maxId=nodeMaxOutEdgeId.get(elem.getKey))
         } catch {
           case NonFatal(exc) =>
             throw new IOException("Parsing failed near line: %d in %s"

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/util/io/AdjacencyListGraphReaderSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/util/io/AdjacencyListGraphReaderSpec.scala
@@ -42,6 +42,11 @@ class AdjacencyListGraphReaderSpec extends WordSpec with Matchers with GraphBeha
     val graph = reader.toSharedArrayBasedDirectedGraph()
   }
 
+  trait ArrayBasedDynamicGraphWithoutRenumberer {
+    val graph = AdjacencyListGraphReader.forIntIds(directory, "toy_6nodes_adj",
+      Executors.newFixedThreadPool(2)).toArrayBasedDynamicDirectedGraph()
+  }
+
   trait GraphWithRenumberer {
     val seqRenumberer = new SequentialNodeNumberer[Int]()
     val graph = AdjacencyListGraphReader.forIntIds(directory, "toy_6nodes_adj",
@@ -83,6 +88,22 @@ class AdjacencyListGraphReaderSpec extends WordSpec with Matchers with GraphBeha
       }
     }
 
+  }
+
+  "AdjacencyListReader producing ArrayBasedDynamicDirectedGraph" should {
+    "provide the correct graph properties" in {
+      new ArrayBasedDynamicGraphWithoutRenumberer {
+        graph.nodeCount should be(6)
+        graph.edgeCount should be(11L)
+        graph.maxNodeId should be(15)
+      }
+    }
+
+    "contain the right nodes and edges" in {
+      new ArrayBasedDynamicGraphWithoutRenumberer {
+        behave like graphEquivalentToMap(graph, toy6nodeMap)
+      }
+    }
   }
 
   "AdjacencyListReader renumbered" when {

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/util/io/AdjacencyListGraphReaderSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/util/io/AdjacencyListGraphReaderSpec.scala
@@ -43,8 +43,8 @@ class AdjacencyListGraphReaderSpec extends WordSpec with Matchers with GraphBeha
   }
 
   trait ArrayBasedDynamicGraphWithoutRenumberer {
-    val graph = AdjacencyListGraphReader.forIntIds(directory, "toy_6nodes_adj",
-      Executors.newFixedThreadPool(2)).toArrayBasedDynamicDirectedGraph()
+    val graph = AdjacencyListGraphReader.forIntIds(directory, "toy_6nodes_adj")
+        .toArrayBasedDynamicDirectedGraph()
   }
 
   trait GraphWithRenumberer {


### PR DESCRIPTION
This pull request fixes a bug where ArrayBasedDynamicDirectedGraph couldn't be created from an adjacency list file. 

Currently the iterator in AdjacencyListGraphReader returns a reference to a single NodeIdEdgesMaxId which is mutated on the next iteration, so if the iterator is read into another collection like a sequence, the sequence will contain many references to the same object.  After this commit AdjacencyListGraphReader constructs a new NodeIdEdgesMaxId on each iteration, which may result in more garbage collection pressure, but won't result in bizzare bugs if users ever convert the iterator to a Seq.

Also, (this change)[https://github.com/twitter/cassovary/commit/8bfa6d96d33e83330dbee81a8675258d1a1a0a48] modified ArrayBasedDynamicDirectedGraph to that it reads reads the entire input into memory before reading any of it, but because I hadn't written a unit test for reading a file into a mutable graph, it was unclear that the `.view` was important for correctness.  I restored `.view` on the input iterator before flattening.   This change also fixes the bug, but I still think it also makes sense to pull my change to AdjacencyListGraphReader unless profiling tests have shown that reusing the same object on different iterations improves performance significantly.  