### PR TITLE
hasp map usage corrected

### DIFF
--- a/cassovary-examples/src/main/java/RandomWalkJava.java
+++ b/cassovary-examples/src/main/java/RandomWalkJava.java
@@ -91,7 +91,7 @@ public class RandomWalkJava {
   @SuppressWarnings("unchecked")
   private static Map<Integer, Integer> scalaIntsMapToJavaMap(scala.collection.Map<Object, Object> map) {
     Map<Object, Object> javaMap = JavaConverters$.MODULE$.mapAsJavaMapConverter(map).asJava();
-    HashMap<Integer, Integer> javaIntsMap = new HashMap<>();
+    HashMap<Integer, Integer> javaIntsMap = new HashMap<Integer, Integer>();
     for(Object key: javaMap.keySet()){
         javaIntsMap.put((Integer)key, (Integer)javaMap.get(key));
     }


### PR DESCRIPTION
Trying to understand how Cassovary works, found this compile time error while trying examples. Fixed it.