### PR TITLE
Add betweenness centrality and shortest path

### DIFF
--- a/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/centrality/BetweennessCentrality.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/centrality/BetweennessCentrality.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.twitter.cassovary.algorithms.centrality
+
+import com.twitter.cassovary.algorithms.shortestpath.SingleSourceShortestPath
+import com.twitter.cassovary.graph._
+
+class BetweennessCentrality(graph: DirectedGraph[Node], normalize: Boolean = true) extends AbstractCentrality(graph) {
+
+  private def combineMap(a: Map[Int, Double], b: Map[Int, Double]): Map[Int, Double] = {
+    (a.keys ++ b.keys).map { k => k -> (a.getOrElse(k, 0.0) + b.getOrElse(k, 0.0)) }.toMap
+  }
+
+  def _recalc(): Unit = {
+    val values = graph.foldLeft(Map.empty[Int, Double]){ (partialValues, n) =>
+      val allPaths = SingleSourceShortestPath(graph, n.id).allShortestPaths
+      val currentValues = allPaths.values.foldLeft(Map.empty[Int, Double]){ (acc, pc) =>
+        val middleNodes = pc.flatMap { p => p.slice(1, p.size - 1) }
+          .groupBy(k => k)
+          .map { k => k._1 -> (k._2.size.toDouble / pc.length) }.toMap
+        combineMap(middleNodes, acc)
+      }
+      combineMap(partialValues, currentValues)
+    }
+    val nc = graph.nodeCount
+    val scale = if (normalize && nc >= 2) 1.0 / ((nc - 1) * (nc - 2)) else 1.0
+    values.foreach { case (i, v) => centralityValues(i) = v * scale }
+  }
+}

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/centrality/BetweennessCentrality.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/centrality/BetweennessCentrality.scala
@@ -19,7 +19,7 @@ import com.twitter.cassovary.graph._
 class BetweennessCentrality(graph: DirectedGraph[Node], normalize: Boolean = true) extends AbstractCentrality(graph) {
 
   private def combineMap(a: Map[Int, Double], b: Map[Int, Double]): Map[Int, Double] = {
-    (a.keys ++ b.keys).map { k => k -> (a.getOrElse(k, 0.0) + b.getOrElse(k, 0.0)) }.toMap
+    (a.keySet ++ b.keySet).map { k => k -> (a.getOrElse(k, 0.0) + b.getOrElse(k, 0.0)) }.toMap
   }
 
   def _recalc(): Unit = {

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/centrality/BetweennessCentrality.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/centrality/BetweennessCentrality.scala
@@ -26,7 +26,7 @@ class BetweennessCentrality(graph: DirectedGraph[Node], normalize: Boolean = tru
     val values = graph.foldLeft(Map.empty[Int, Double]){ (partialValues, n) =>
       val allPaths = new SingleSourceShortestPath(graph, n.id).allShortestPaths
       val currentValues = allPaths.values.foldLeft(Map.empty[Int, Double]){ (acc, pc) =>
-        val middleNodes = pc.flatMap { p => p.slice(1, p.size - 1) }
+        val middleNodes = pc.flatMap { p => p.slice(1, p.size) }
           .groupBy(k => k)
           .map { k => k._1 -> (k._2.size.toDouble / pc.length) }.toMap
         combineMap(middleNodes, acc)

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/centrality/BetweennessCentrality.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/centrality/BetweennessCentrality.scala
@@ -24,7 +24,7 @@ class BetweennessCentrality(graph: DirectedGraph[Node], normalize: Boolean = tru
 
   def _recalc(): Unit = {
     val values = graph.foldLeft(Map.empty[Int, Double]){ (partialValues, n) =>
-      val allPaths = SingleSourceShortestPath(graph, n.id).allShortestPaths
+      val allPaths = new SingleSourceShortestPath(graph, n.id).allShortestPaths
       val currentValues = allPaths.values.foldLeft(Map.empty[Int, Double]){ (acc, pc) =>
         val middleNodes = pc.flatMap { p => p.slice(1, p.size - 1) }
           .groupBy(k => k)

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/shortestpath/ShortestPath.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/shortestpath/ShortestPath.scala
@@ -1,15 +1,40 @@
+/*
+ * Copyright 2015 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.twitter.cassovary.algorithms.shortestpath
 
 import com.twitter.cassovary.graph.{Node, DirectedGraph}
 
+/**
+ * A base trait for all ShortestPath algorithm implementations
+ */
 trait ShortestPath {
   type Path  = Seq[Int]
-  type Paths = Seq[Seq[Int]]
-  type Stack = List[Seq[Int]]
+  type Paths = Seq[Path]
+  type Stack = List[Path]
 
   def graph: DirectedGraph[Node]
 
-  def shortestPaths(n: Int): Paths
+  /**
+   * Calculate the shortest path to a given target
+   * @param target The integer ID of the target node
+   * @return A sequence of paths.  If no shortest path exists, the list will be empty
+   */
+  def shortestPaths(target: Int): Paths
 
-  def allShortestPaths: Map[Int, Paths] = graph.toList.map { n => n.id -> shortestPaths(n.id) }.toMap
+  /**
+   * Calculate all shortest paths for all target nodes in the graph
+   * @return A map of integer node id to paths
+   */
+  def allShortestPaths: Map[Int, Paths] = graph.map { n => n.id -> shortestPaths(n.id) }.toMap
 }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/shortestpath/ShortestPath.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/shortestpath/ShortestPath.scala
@@ -20,7 +20,6 @@ import com.twitter.cassovary.graph.{Node, DirectedGraph}
  */
 trait ShortestPath {
   type Path  = Seq[Int]
-  type Stack = List[Path]
 
   val graph: DirectedGraph[Node]
 

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/shortestpath/ShortestPath.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/shortestpath/ShortestPath.scala
@@ -20,21 +20,26 @@ import com.twitter.cassovary.graph.{Node, DirectedGraph}
  */
 trait ShortestPath {
   type Path  = Seq[Int]
-  type Paths = Seq[Path]
   type Stack = List[Path]
 
-  def graph: DirectedGraph[Node]
+  val graph: DirectedGraph[Node]
 
   /**
-   * Calculate the shortest path to a given target
+   * Source node for all shortest paths calculated by `shortestPaths`
+   */
+  val source: Int
+
+  /**
+   * Calculate the shortest paths to `target` from a given source node.  The source
+   * node must be provided as an instance variable of all implementing subclasses.
    * @param target The integer ID of the target node
    * @return A sequence of paths.  If no shortest path exists, the list will be empty
    */
-  def shortestPaths(target: Int): Paths
+  def shortestPaths(target: Int): Seq[Path]
 
   /**
    * Calculate all shortest paths for all target nodes in the graph
    * @return A map of integer node id to paths
    */
-  def allShortestPaths: Map[Int, Paths] = graph.map { n => n.id -> shortestPaths(n.id) }.toMap
+  def allShortestPaths: Map[Int, Seq[Path]] = graph.map { n => n.id -> shortestPaths(n.id) }.toMap
 }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/shortestpath/ShortestPath.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/shortestpath/ShortestPath.scala
@@ -1,0 +1,15 @@
+package com.twitter.cassovary.algorithms.shortestpath
+
+import com.twitter.cassovary.graph.{Node, DirectedGraph}
+
+trait ShortestPath {
+  type Path  = Seq[Int]
+  type Paths = Seq[Seq[Int]]
+  type Stack = List[Seq[Int]]
+
+  def graph: DirectedGraph[Node]
+
+  def shortestPaths(n: Int): Paths
+
+  def allShortestPaths: Map[Int, Paths] = graph.toList.map { n => n.id -> shortestPaths(n.id) }.toMap
+}

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/shortestpath/SingleSourceShortestPath.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/shortestpath/SingleSourceShortestPath.scala
@@ -1,0 +1,44 @@
+package com.twitter.cassovary.algorithms.shortestpath
+
+import com.twitter.cassovary.graph.{Node, GraphDir, BreadthFirstTraverser, DirectedGraph}
+
+case class SingleSourceShortestPath(graph: DirectedGraph[Node], source: Int) extends ShortestPath {
+
+  val bfs = new BreadthFirstTraverser(graph, GraphDir.OutDir, Seq(source))
+  private val (nodes, depths)  = (bfs.toList, bfs.allDepths)
+  private val previous = nodes.map { n =>
+    n.id -> n.inboundNodes().filter { in => depths(in) == depths(n.id) - 1}
+  }.toMap
+
+  private def walkOnGraph(currStack: Stack, currTop: Int): (Stack, Int, Path) = {
+    val node  = currStack(currTop)(0)
+    val index = currStack(currTop)(1)
+
+    val path = if (node == source)
+      currStack.take(currTop + 1).reverse.map { k => k(0) }.toSeq
+    else
+      Seq.empty[Int]
+
+    val (stack, top) = if (previous(node).length > index) {
+      val newStack = if (currTop + 1 == currStack.length)
+        currStack :+ Seq(previous(node)(index), 0)
+      else
+        currStack.zipWithIndex.map { case (seq, in) => if (in == currTop + 1) Seq(previous(node)(index), 0) else seq}
+      (newStack, currTop + 1)
+    }
+    else {
+      val newStack = currStack.zipWithIndex.map { case (seq, in) => if (in == currTop - 1) Seq(seq(0), seq(1) + 1) else seq}
+      (newStack, currTop - 1)
+    }
+    (stack, top, path)
+  }
+
+  def shortestPaths(target: Int): Paths = {
+    lazy val stream: Stream[(Stack, Int, Path)] =
+      (List(Seq(target, 0)), 0, Seq.empty[Int]) #:: stream.map { case (s, t, p) => walkOnGraph(s,t) }
+
+    stream.takeWhile{ case (_, t, _) => t >= 0}.toList
+      .filter{ case (_, _, p) => p.nonEmpty }
+      .map{ _._3 }.toSeq
+  }
+}

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/shortestpath/SingleSourceShortestPath.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/shortestpath/SingleSourceShortestPath.scala
@@ -1,8 +1,27 @@
+/*
+ * Copyright 2015 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.twitter.cassovary.algorithms.shortestpath
 
-import com.twitter.cassovary.graph.{Node, GraphDir, BreadthFirstTraverser, DirectedGraph}
+import com.twitter.cassovary.graph._
 
-case class SingleSourceShortestPath(graph: DirectedGraph[Node], source: Int) extends ShortestPath {
+/**
+ * Starting from a given source, calculate the shortest paths from that source to
+ * a given target node.  This algorithm returns all shortest paths available not just
+ * a single shortest path.
+ * @param source The source node with which all shortest paths start.
+ */
+class SingleSourceShortestPath(val graph: DirectedGraph[Node], source: Int) extends ShortestPath {
 
   val bfs = new BreadthFirstTraverser(graph, GraphDir.OutDir, Seq(source))
   private val (nodes, depths)  = (bfs.toList, bfs.allDepths)
@@ -10,6 +29,17 @@ case class SingleSourceShortestPath(graph: DirectedGraph[Node], source: Int) ext
     n.id -> n.inboundNodes().filter { in => depths(in) == depths(n.id) - 1}
   }.toMap
 
+  /**
+   * Talk a walk on our graph starting at a given node.  Once the source node has been reached,
+   * the walk continues by retracing its steps.  At each step backward, the algorithm asks if there
+   * exist any other nodes that could lead to a shortest path.  If so, walk along those nodes, else
+   * continue to walk backward.  The algorithm terminates when it has reached the target node and
+   * has no other place to go but to retrace its steps (which is impossible).
+   * @param currStack The current path of nodes that the algorithm is following.
+   * @param currTop The number of steps the algorithm has taken from target toward source.
+   * @return A Tuple3 consisting of a new stack, a new top, and a path.  The path will be
+   *         empty if a shortest path was not successfully found during that iteration.
+   */
   private def walkOnGraph(currStack: Stack, currTop: Int): (Stack, Int, Path) = {
     val node  = currStack(currTop)(0)
     val index = currStack(currTop)(1)
@@ -23,11 +53,13 @@ case class SingleSourceShortestPath(graph: DirectedGraph[Node], source: Int) ext
       val newStack = if (currTop + 1 == currStack.length)
         currStack :+ Seq(previous(node)(index), 0)
       else
-        currStack.zipWithIndex.map { case (seq, in) => if (in == currTop + 1) Seq(previous(node)(index), 0) else seq}
+        currStack.zipWithIndex.map { case (seq, in) =>
+          if (in == currTop + 1) Seq(previous(node)(index), 0) else seq }
       (newStack, currTop + 1)
     }
     else {
-      val newStack = currStack.zipWithIndex.map { case (seq, in) => if (in == currTop - 1) Seq(seq(0), seq(1) + 1) else seq}
+      val newStack = currStack.zipWithIndex.map { case (seq, in) =>
+        if (in == currTop - 1) Seq(seq(0), seq(1) + 1) else seq }
       (newStack, currTop - 1)
     }
     (stack, top, path)
@@ -37,7 +69,7 @@ case class SingleSourceShortestPath(graph: DirectedGraph[Node], source: Int) ext
     lazy val stream: Stream[(Stack, Int, Path)] =
       (List(Seq(target, 0)), 0, Seq.empty[Int]) #:: stream.map { case (s, t, p) => walkOnGraph(s,t) }
 
-    stream.takeWhile{ case (_, t, _) => t >= 0}.toList
+    stream.takeWhile{ case (_, t, _) => t >= 0 }.toList
       .filter{ case (_, _, p) => p.nonEmpty }
       .map{ _._3 }.toSeq
   }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/shortestpath/SingleSourceShortestPath.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/shortestpath/SingleSourceShortestPath.scala
@@ -21,7 +21,7 @@ import com.twitter.cassovary.graph._
  * a single shortest path.
  * @param source The source node with which all shortest paths start.
  */
-class SingleSourceShortestPath(val graph: DirectedGraph[Node], source: Int) extends ShortestPath {
+class SingleSourceShortestPath(val graph: DirectedGraph[Node], val source: Int) extends ShortestPath {
 
   val bfs = new BreadthFirstTraverser(graph, GraphDir.OutDir, Seq(source))
   private val (nodes, depths)  = (bfs.toList, bfs.allDepths)
@@ -65,7 +65,7 @@ class SingleSourceShortestPath(val graph: DirectedGraph[Node], source: Int) exte
     (stack, top, path)
   }
 
-  def shortestPaths(target: Int): Paths = {
+  def shortestPaths(target: Int): Seq[Path] = {
     lazy val stream: Stream[(Stack, Int, Path)] =
       (List(Seq(target, 0)), 0, Seq.empty[Int]) #:: stream.map { case (s, t, p) => walkOnGraph(s,t) }
 

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/shortestpath/SingleSourceShortestPath.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/shortestpath/SingleSourceShortestPath.scala
@@ -22,55 +22,10 @@ import com.twitter.cassovary.graph._
  * @param source The source node with which all shortest paths start.
  */
 class SingleSourceShortestPath(val graph: DirectedGraph[Node], val source: Int) extends ShortestPath {
+  private val spt = new ShortestPathsTraverser(graph, Seq(source))
 
-  val bfs = new BreadthFirstTraverser(graph, GraphDir.OutDir, Seq(source))
-  private val (nodes, depths)  = (bfs.toList, bfs.allDepths)
-  private val previous = nodes.map { n =>
-    n.id -> n.inboundNodes().filter { in => depths(in) == depths(n.id) - 1}
-  }.toMap
+  //We need to run the iterator...
+  spt.toList
 
-  /**
-   * Talk a walk on our graph starting at a given node.  Once the source node has been reached,
-   * the walk continues by retracing its steps.  At each step backward, the algorithm asks if there
-   * exist any other nodes that could lead to a shortest path.  If so, walk along those nodes, else
-   * continue to walk backward.  The algorithm terminates when it has reached the target node and
-   * has no other place to go but to retrace its steps (which is impossible).
-   * @param currStack The current path of nodes that the algorithm is following.
-   * @param currTop The number of steps the algorithm has taken from target toward source.
-   * @return A Tuple3 consisting of a new stack, a new top, and a path.  The path will be
-   *         empty if a shortest path was not successfully found during that iteration.
-   */
-  private def walkOnGraph(currStack: Stack, currTop: Int): (Stack, Int, Path) = {
-    val node  = currStack(currTop)(0)
-    val index = currStack(currTop)(1)
-
-    val path = if (node == source)
-      currStack.take(currTop + 1).reverse.map { k => k(0) }.toSeq
-    else
-      Seq.empty[Int]
-
-    val (stack, top) = if (previous(node).length > index) {
-      val newStack = if (currTop + 1 == currStack.length)
-        currStack :+ Seq(previous(node)(index), 0)
-      else
-        currStack.zipWithIndex.map { case (seq, in) =>
-          if (in == currTop + 1) Seq(previous(node)(index), 0) else seq }
-      (newStack, currTop + 1)
-    }
-    else {
-      val newStack = currStack.zipWithIndex.map { case (seq, in) =>
-        if (in == currTop - 1) Seq(seq(0), seq(1) + 1) else seq }
-      (newStack, currTop - 1)
-    }
-    (stack, top, path)
-  }
-
-  def shortestPaths(target: Int): Seq[Path] = {
-    lazy val stream: Stream[(Stack, Int, Path)] =
-      (List(Seq(target, 0)), 0, Seq.empty[Int]) #:: stream.map { case (s, t, p) => walkOnGraph(s,t) }
-
-    stream.takeWhile{ case (_, t, _) => t >= 0 }.toList
-      .filter{ case (_, _, p) => p.nonEmpty }
-      .map{ _._3 }.toSeq
-  }
+  def shortestPaths(target: Int): Seq[Path] = spt.paths(target)
 }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/TestGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/TestGraph.scala
@@ -87,6 +87,18 @@ object TestGraphs {
       NodeIdEdgesMaxId(15, Array(10, 11))
       )
 
+  val g8SeqIterator = Seq(
+      NodeIdEdgesMaxId(1, Array(2,3)),
+      NodeIdEdgesMaxId(2, Array(4,5)),
+      NodeIdEdgesMaxId(3, Array(7)),
+      NodeIdEdgesMaxId(4, Array(3, 6)),
+      NodeIdEdgesMaxId(5, Array(4,6)),
+      NodeIdEdgesMaxId(6, Array(8,9)),
+      NodeIdEdgesMaxId(7, Array(6)),
+      NodeIdEdgesMaxId(8, Array(1)),
+      NodeIdEdgesMaxId(9, Array(1,4))
+  )
+
   val nodeSeqIteratorWithEmpty = Seq(
     NodeIdEdgesMaxId(0, Array.empty[Int]),
     NodeIdEdgesMaxId(1, Array.empty[Int])
@@ -115,6 +127,9 @@ object TestGraphs {
   def g7_onlyout = ArrayBasedDirectedGraph(nodeSeqIterator2, StoredGraphDir.OnlyOut,
     NeighborsSortingStrategy.LeaveUnsorted)
   def g7_onlyin = ArrayBasedDirectedGraph(nodeSeqIterator2, StoredGraphDir.OnlyIn,
+    NeighborsSortingStrategy.LeaveUnsorted)
+
+  def g8 = ArrayBasedDirectedGraph(g8SeqIterator, StoredGraphDir.BothInOut,
     NeighborsSortingStrategy.LeaveUnsorted)
 
   // Bipartite Graph

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/Traverser.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/Traverser.scala
@@ -409,6 +409,8 @@ trait DepthTracker extends QueueBasedTraverser[Node] {
     super.enqueue(nodes, from)
   }
 
+  def allDepths: collection.Map[Int, Int] = depthTracker.infoAllNodes
+
   def depth(id: Int) = depthTracker.infoOfNode(id)
 }
 

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/algorithms/centrality/BetweennessCentralitySpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/algorithms/centrality/BetweennessCentralitySpec.scala
@@ -19,7 +19,6 @@ import org.scalatest.{Matchers, WordSpec}
 class BetweennessCentralitySpec extends WordSpec with Matchers {
   lazy val graph = TestGraphs.g6
 
-
   "Betweenness centrality" should {
     "return correctly normalized values when requesting normalization" in {
       val bc = new BetweennessCentrality(graph)

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/algorithms/centrality/BetweennessCentralitySpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/algorithms/centrality/BetweennessCentralitySpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.twitter.cassovary.algorithms.centrality
+
+import com.twitter.cassovary.graph._
+import org.scalatest.{Matchers, WordSpec}
+
+class BetweennessCentralitySpec extends WordSpec with Matchers {
+  lazy val graph = TestGraphs.g6
+
+
+  "Betweenness centrality" should {
+    "return correctly normalized values when requesting normalization" in {
+      val bc = new BetweennessCentrality(graph)
+
+      bc(graph.getNodeById(10).get) should be (.250 +- .005)
+      bc(graph.getNodeById(11).get) should be (.133 +- .005)
+      bc(graph.getNodeById(12).get) should be (.033 +- .005)
+      bc(graph.getNodeById(13).get) should be (.033 +- .005)
+      bc(graph.getNodeById(14).get) should be (.550 +- .005)
+      bc(graph.getNodeById(15).get) should be (.550 +- .005)
+    }
+
+    "return somewhat large values when requesting no normalization" in {
+      val bc = new BetweennessCentrality(graph, false)
+
+      bc(graph.getNodeById(10).get) should be (5.000  +- .005)
+      bc(graph.getNodeById(11).get) should be (2.666  +- .005)
+      bc(graph.getNodeById(12).get) should be (0.666  +- .005)
+      bc(graph.getNodeById(13).get) should be (0.666  +- .005)
+      bc(graph.getNodeById(14).get) should be (11.000 +- .005)
+      bc(graph.getNodeById(15).get) should be (11.000 +- .005)
+    }
+  }
+}

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/algorithms/shortestpath/SingleSourceShortestPathSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/algorithms/shortestpath/SingleSourceShortestPathSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.twitter.cassovary.algorithms.shortestpath
+
+import com.twitter.cassovary.graph._
+import org.scalatest.{Matchers, WordSpec}
+
+class SingleSourceShortestPathSpec extends WordSpec with Matchers {
+  lazy val graph = TestGraphs.g6
+
+  "Single source shortest path" should {
+
+    "return 0 paths when the source node is the same as the target node" in {
+      val sp = new SingleSourceShortestPath(graph, 10)
+      sp.shortestPaths(10).length shouldEqual 0
+    }
+
+    "return 3 paths when source node is 10 and target node is 14" in {
+      val sp = new SingleSourceShortestPath(graph, 10)
+      val paths = sp.shortestPaths(14)
+      paths.length shouldEqual 3
+      paths(0) shouldEqual Seq(10,11,14)
+      paths(1) shouldEqual Seq(10,12,14)
+      paths(2) shouldEqual Seq(10,13,14)
+    }
+
+    "return all paths from a given source node to all target nodes" in {
+      val sp = new SingleSourceShortestPath(graph, 10)
+      val allPaths = sp.allShortestPaths
+      allPaths.size shouldEqual 6
+      allPaths(10).length shouldEqual 0
+      allPaths(14).length shouldEqual 3
+      allPaths(15).length shouldEqual 3
+      allPaths(14)(0) shouldEqual Seq(10,11,14)
+      allPaths(14)(1) shouldEqual Seq(10,12,14)
+      allPaths(14)(2) shouldEqual Seq(10,13,14)
+    }
+  }
+}

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/algorithms/shortestpath/SingleSourceShortestPathSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/algorithms/shortestpath/SingleSourceShortestPathSpec.scala
@@ -23,28 +23,28 @@ class SingleSourceShortestPathSpec extends WordSpec with Matchers {
 
     "return 0 paths when the source node is the same as the target node" in {
       val sp = new SingleSourceShortestPath(graph, 10)
-      sp.shortestPaths(10).length shouldEqual 0
+      sp.shortestPaths(10).length shouldEqual 1
     }
 
     "return 3 paths when source node is 10 and target node is 14" in {
       val sp = new SingleSourceShortestPath(graph, 10)
       val paths = sp.shortestPaths(14)
       paths.length shouldEqual 3
-      paths(0) shouldEqual Seq(10,11,14)
-      paths(1) shouldEqual Seq(10,12,14)
-      paths(2) shouldEqual Seq(10,13,14)
+      paths(0) shouldEqual Seq(10,11)
+      paths(1) shouldEqual Seq(10,12)
+      paths(2) shouldEqual Seq(10,13)
     }
 
     "return all paths from a given source node to all target nodes" in {
       val sp = new SingleSourceShortestPath(graph, 10)
       val allPaths = sp.allShortestPaths
       allPaths.size shouldEqual 6
-      allPaths(10).length shouldEqual 0
+      allPaths(10).length shouldEqual 1
       allPaths(14).length shouldEqual 3
       allPaths(15).length shouldEqual 3
-      allPaths(14)(0) shouldEqual Seq(10,11,14)
-      allPaths(14)(1) shouldEqual Seq(10,12,14)
-      allPaths(14)(2) shouldEqual Seq(10,13,14)
+      allPaths(14)(0) shouldEqual Seq(10,11)
+      allPaths(14)(1) shouldEqual Seq(10,12)
+      allPaths(14)(2) shouldEqual Seq(10,13)
     }
   }
 }

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/TraverserSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/TraverserSpec.scala
@@ -27,6 +27,35 @@ class TraverserSpec extends WordSpec with MockitoSugar with Matchers {
     def hasNext = i < 40
   }
 
+  "ShortestPathTraverser" should {
+    "return all shortest paths" in {
+      val spt = new ShortestPathsTraverser(TestGraphs.g8, Seq(1))
+      spt.toList
+      spt.numPaths(8) shouldEqual 3
+      spt.paths(8) shouldEqual Seq(Seq(1, 2, 4, 6), Seq(1, 2, 5, 6), Seq(1, 3, 7, 6))
+
+      val spt2 = new ShortestPathsTraverser(TestGraphs.g5, Seq(10))
+      spt2.toList
+      spt2.numPaths(14) shouldEqual 1
+      spt2.paths(14) shouldEqual Seq(Seq(10,13))
+    }
+
+    "return different paths when direction is reversed" in {
+      val spt = new ShortestPathsTraverser(TestGraphs.g8, Seq(1), GraphDir.InDir)
+      spt.toList
+      spt.numPaths(5) shouldEqual 2
+      spt.paths(5) shouldEqual Seq(Seq(1, 8, 6), Seq(1, 9, 6))
+    }
+
+    "return no shortest paths longer than 3 when limit is set" in {
+      val spt = new ShortestPathsTraverser(TestGraphs.g8, Seq(1), GraphDir.OutDir, new Walk.Limits(maxDepth = Some(3)))
+      spt.toList
+      spt.numPaths.getOrElse(8, 0) shouldEqual 0
+      spt.paths.getOrElse(8, Seq(Seq())) shouldEqual Seq(Seq())
+    }
+  }
+
+
   "BoundedIterator" should {
     "satisfy a limit" in {
       val biter = new TestIter with BoundedIterator[Int] {


### PR DESCRIPTION
New clean pull request for betweenness centrality that is up to date with master (specifically the parameterization by node type).  

This is still a WIP.  Please leave some comments on how to make this better as betweenness centrality is a rather complicated thing to calculate.

In plain English, we want to find all of the shortest paths from node i to node j.  We then collect all of the middle nodes between node i and node j not including i or j.  We then sum over those nodes dividing by the total number of shortest paths.  We do this for all nodes i, j that are contained in the graph.  

The most complicated part of this is calculating all of the shortest paths simultaneously in a timely fashion.  The code may be a little opaque due to this.  We could sacrifice efficiently for transparency if we determine that to be the best route.

@pankajgupta @szymonm @AnishShah please feel free to provide feedback.  Thanks!