### PR TITLE
Add centrality performance benchmarks

### DIFF
--- a/cassovary-benchmarks/src/main/scala/com/twitter/cassovary/CentralityBenchmark.scala
+++ b/cassovary-benchmarks/src/main/scala/com/twitter/cassovary/CentralityBenchmark.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.twitter.cassovary
+
+import com.twitter.cassovary.algorithms.centrality.{ClosenessCentrality, DegreeCentrality}
+import com.twitter.cassovary.graph.{GraphDir, Node, DirectedGraph}
+
+sealed abstract class DegreeCentralityBenchmark(graph: DirectedGraph[Node], dir: GraphDir.GraphDir)
+  extends OperationBenchmark {
+  def operation(): Unit = {
+    new DegreeCentrality(graph, dir)
+  }
+}
+
+class InDegreeCentralityBenchmark(graph: DirectedGraph[Node])
+  extends DegreeCentralityBenchmark(graph, GraphDir.InDir)
+
+class OutDegreeCentralityBenchmark(graph: DirectedGraph[Node])
+  extends DegreeCentralityBenchmark(graph, GraphDir.OutDir)
+
+class ClosenessCentralityBenchmark(graph: DirectedGraph[Node])
+  extends OperationBenchmark {
+  def operation(): Unit = {
+    new ClosenessCentrality(graph)
+  }
+}

--- a/cassovary-benchmarks/src/main/scala/com/twitter/cassovary/PerformanceBenchmark.scala
+++ b/cassovary-benchmarks/src/main/scala/com/twitter/cassovary/PerformanceBenchmark.scala
@@ -85,7 +85,7 @@ object PerformanceBenchmark extends App with GzipGraphDownloader {
   val globalPRFlag = flags("globalpr", false, "run global pagerank benchmark")
   val pprFlag = flags("ppr", false, "run personalized pagerank benchmark")
   val centFlag = flags("c", DEFAULT_CENTRALITY_ALGORITHM,
-    "run the specified centrality algorithm (indegree, outdegree, closeness)")
+    "run the specified centrality algorithm (indegree, outdegree, closeness, all)")
   val getNodeFlag = flags("gn", 0, "run getNodeById benchmark with a given number of steps")
   val reps = flags("reps", DEFAULT_REPS, "number of times to run benchmark")
   val adjacencyList = flags("a", false, "graph in adjacency list format")

--- a/cassovary-benchmarks/src/main/scala/com/twitter/cassovary/PerformanceBenchmark.scala
+++ b/cassovary-benchmarks/src/main/scala/com/twitter/cassovary/PerformanceBenchmark.scala
@@ -73,6 +73,7 @@ object PerformanceBenchmark extends App with GzipGraphDownloader {
    */
   val DEFAULT_REPS = 10
   val defaultLocalGraphFile = "facebook"
+  val DEFAULT_CENTRALITY_ALGORITHM = "all"
 
   val flags = new Flags("Performance benchmark")
   val localFileFlag = flags("local", defaultLocalGraphFile,
@@ -83,9 +84,8 @@ object PerformanceBenchmark extends App with GzipGraphDownloader {
   val helpFlag = flags("h", false, "Print usage")
   val globalPRFlag = flags("globalpr", false, "run global pagerank benchmark")
   val pprFlag = flags("ppr", false, "run personalized pagerank benchmark")
-  val idcFlag = flags("idc", false, "run in-degree centrality benchmark")
-  val odcFlag = flags("odc", false, "run out-degree centrality benchmark")
-  val ccFlag  = flags("cc",  false, "run closeness centrality benchmark")
+  val centFlag = flags("c", DEFAULT_CENTRALITY_ALGORITHM,
+    "run the specified centrality algorithm (indegree, outdegree, closeness)")
   val getNodeFlag = flags("gn", 0, "run getNodeById benchmark with a given number of steps")
   val reps = flags("reps", DEFAULT_REPS, "number of times to run benchmark")
   val adjacencyList = flags("a", false, "graph in adjacency list format")
@@ -98,9 +98,16 @@ object PerformanceBenchmark extends App with GzipGraphDownloader {
   }
   if (globalPRFlag()) { benchmarks += (g => new PageRankBenchmark(g)) }
   if (pprFlag()) { benchmarks += (g => new PersonalizedPageRankBenchmark(g)) }
-  if (idcFlag()) { benchmarks += (g => new InDegreeCentralityBenchmark(g)) }
-  if (odcFlag()) { benchmarks += (g => new OutDegreeCentralityBenchmark(g)) }
-  if (ccFlag())  { benchmarks += (g => new ClosenessCentralityBenchmark(g)) }
+
+  centFlag() match {
+    case "indegree"  => benchmarks += (g => new InDegreeCentralityBenchmark(g))
+    case "outdegree" => benchmarks += (g => new OutDegreeCentralityBenchmark(g))
+    case "closeness" => benchmarks += (g => new ClosenessCentralityBenchmark(g))
+    case "all"       => benchmarks.append(g => new InDegreeCentralityBenchmark(g),
+      g => new OutDegreeCentralityBenchmark(g), g => new ClosenessCentralityBenchmark(g))
+    case s: String => printf("%s is not a valid centrality option.  Please use indegree, outdegree, or closeness.\n", s)
+  }
+
   if (getNodeFlag() > 0) { benchmarks += (g => new GetNodeByIdBenchmark(g, getNodeFlag(),
     GraphDir.OutDir))}
   if (helpFlag()) {

--- a/cassovary-benchmarks/src/main/scala/com/twitter/cassovary/PerformanceBenchmark.scala
+++ b/cassovary-benchmarks/src/main/scala/com/twitter/cassovary/PerformanceBenchmark.scala
@@ -83,6 +83,9 @@ object PerformanceBenchmark extends App with GzipGraphDownloader {
   val helpFlag = flags("h", false, "Print usage")
   val globalPRFlag = flags("globalpr", false, "run global pagerank benchmark")
   val pprFlag = flags("ppr", false, "run personalized pagerank benchmark")
+  val idcFlag = flags("idc", false, "run in-degree centrality benchmark")
+  val odcFlag = flags("odc", false, "run out-degree centrality benchmark")
+  val ccFlag  = flags("cc",  false, "run closeness centrality benchmark")
   val getNodeFlag = flags("gn", 0, "run getNodeById benchmark with a given number of steps")
   val reps = flags("reps", DEFAULT_REPS, "number of times to run benchmark")
   val adjacencyList = flags("a", false, "graph in adjacency list format")
@@ -95,6 +98,9 @@ object PerformanceBenchmark extends App with GzipGraphDownloader {
   }
   if (globalPRFlag()) { benchmarks += (g => new PageRankBenchmark(g)) }
   if (pprFlag()) { benchmarks += (g => new PersonalizedPageRankBenchmark(g)) }
+  if (idcFlag()) { benchmarks += (g => new InDegreeCentralityBenchmark(g)) }
+  if (odcFlag()) { benchmarks += (g => new OutDegreeCentralityBenchmark(g)) }
+  if (ccFlag())  { benchmarks += (g => new ClosenessCentralityBenchmark(g)) }
   if (getNodeFlag() > 0) { benchmarks += (g => new GetNodeByIdBenchmark(g, getNodeFlag(),
     GraphDir.OutDir))}
   if (helpFlag()) {


### PR DESCRIPTION
After 500 iterations for in-degree, and out-degree, and 10 iterations for closeness:
<table>
  <tr>
    <td></td><td><b>In-Degree</b></td><td><b>Out-Degree</b></td><td><b>Closeness</b></td>
  </tr>
  <tr>
    <td><b>Facebook</b></td><td>268 &mu;s</td><td>348 &mu;s</td><td>3 s 521 ms</td>
  </tr>
  <tr>
    <td><b>Wiki</b></td><td>238 &mu;s</td><td>241 &mu;s</td><td>17 s 514 ms</td>
  </tr>
</table>
The degree centrality calculations are very fast, however, the closeness centrality calculation is rather slow.  We should try to find some potential optimizations in the future.

Once betweenness centrality has been merged, I will add a benchmark for that as well.