### PR TITLE
Ask Travis CI to retry resolution and downloads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,8 @@ jdk:
   - oraclejdk7
   - oraclejdk8
 
+before_script:
+  - travis_retry sbt ++$TRAVIS_SCALA_VERSION update
+
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test


### PR DESCRIPTION
@pankajgupta We're investigating the `maven.twttr.com` problems internally, but I wanted to see whether this workaround (which we're using in other projects) will fix the issue here. It only retries the resolution and downloading step, so it won't slow down notifications on pull requests with "real" failures.