### PR TITLE
Modify page rank to work with dangling nodes

### DIFF
--- a/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/linkanalysis/LinkAnalysis.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/linkanalysis/LinkAnalysis.scala
@@ -91,7 +91,7 @@ abstract class LinkAnalysis[T <: IterationState](graph: DirectedGraph[Node],
     if (graph.maxNodeId.toDouble / graph.nodeCount > 1.1 && graph.maxNodeId - graph.nodeCount > 1000000)
       log.info("Warning - you may be able to reduce the memory usage by renumbering this graph!")
 
-    log.debug(s"Initializing starting ${modelName}...")
+    log.debug(s"Initializing starting $modelName...")
     val progress = Progress(s"${modelName}_init", 65536, Some(graph.nodeCount))
 
     def terminate(currState: IterationState): Boolean = if (maxIterations.isDefined)

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/TestGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/TestGraph.scala
@@ -64,6 +64,17 @@ object TestGraphs {
     TestNode(2, Nil, List(1))
     )
 
+  val g3_dangling_seq = Seq(
+    NodeIdEdgesMaxId(0, Array(1)),
+    NodeIdEdgesMaxId(1, Array(2)),
+    NodeIdEdgesMaxId(2, Array()))
+
+  val g3_dangling_out = ArrayBasedDirectedGraph(g3_dangling_seq, StoredGraphDir.OnlyOut,
+    NeighborsSortingStrategy.LeaveUnsorted)
+
+  val g3_dangling_in = ArrayBasedDirectedGraph(g3_dangling_seq, StoredGraphDir.OnlyIn,
+    NeighborsSortingStrategy.LeaveUnsorted)
+
   def g3 = ArrayBasedDirectedGraph(Seq(
     NodeIdEdgesMaxId(10, Array(11, 12)),
     NodeIdEdgesMaxId(11, Array(12)),
@@ -77,6 +88,26 @@ object TestGraphs {
     NodeIdEdgesMaxId(13, Array(14)),
     NodeIdEdgesMaxId(14, Array())
     ), StoredGraphDir.BothInOut, NeighborsSortingStrategy.LeaveUnsorted)
+
+  def dangling_g7 = ArrayBasedDirectedGraph(Seq(
+    NodeIdEdgesMaxId(1, Array(2)),
+    NodeIdEdgesMaxId(2, Array(3, 4)),
+    NodeIdEdgesMaxId(3, Array()),
+    NodeIdEdgesMaxId(4, Array()),
+    NodeIdEdgesMaxId(5, Array(6)),
+    NodeIdEdgesMaxId(6, Array(1, 2, 7)),
+    NodeIdEdgesMaxId(7, Array())
+  ), StoredGraphDir.OnlyOut, NeighborsSortingStrategy.LeaveUnsorted)
+
+  def dangling_g7_in = ArrayBasedDirectedGraph(Seq(
+    NodeIdEdgesMaxId(1, Array(2)),
+    NodeIdEdgesMaxId(2, Array(3, 4)),
+    NodeIdEdgesMaxId(3, Array()),
+    NodeIdEdgesMaxId(4, Array()),
+    NodeIdEdgesMaxId(5, Array(6)),
+    NodeIdEdgesMaxId(6, Array(1, 2, 7)),
+    NodeIdEdgesMaxId(7, Array())
+  ), StoredGraphDir.OnlyIn, NeighborsSortingStrategy.LeaveUnsorted)
 
   val nodeSeqIterator = Seq(
       NodeIdEdgesMaxId(10, Array(11, 12, 13)),
@@ -95,11 +126,11 @@ object TestGraphs {
   // using testGraph becomes onerous for non-trivial graphs
   def g6 = ArrayBasedDirectedGraph(nodeSeqIterator, StoredGraphDir.BothInOut,
     NeighborsSortingStrategy.LeaveUnsorted)
-
   def g6_onlyout = ArrayBasedDirectedGraph(nodeSeqIterator, StoredGraphDir.OnlyOut,
     NeighborsSortingStrategy.LeaveUnsorted)
   def g6_onlyin = ArrayBasedDirectedGraph(nodeSeqIterator, StoredGraphDir.OnlyIn,
     NeighborsSortingStrategy.LeaveUnsorted)
+
   def g6WithEmptyNodes = ArrayBasedDirectedGraph(nodeSeqIteratorWithEmpty, StoredGraphDir.BothInOut,
     NeighborsSortingStrategy.LeaveUnsorted)
 

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/algorithms/linkanalysis/PageRankSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/algorithms/linkanalysis/PageRankSpec.scala
@@ -32,12 +32,12 @@ class PageRankSpec extends WordSpec with Matchers {
     }
   }
 
-  def testGraphHelper(graph: DirectedGraph[Node], target: Array[Double]) = {
+  def testGraphHelper(graph: DirectedGraph[Node], target: Array[Double], tolerance:Double =0.00005) = {
     val params = PageRankParams(.85, None)
     val pr = new PageRank(graph, params)
     val finalIter = pr.run()
 
-    (finalIter.pageRank zip target) foreach { case(calculated, goal) => calculated should be (goal +- 0.00005) }
+    (finalIter.pageRank zip target) foreach { case(calculated, goal) => calculated should be (goal +- tolerance) }
   }
 
   lazy val graphG6 = TestGraphs.g6
@@ -91,7 +91,23 @@ class PageRankSpec extends WordSpec with Matchers {
       val pr = new PageRank(graphComplete, params)
 
       val pagerank = pr.run().pageRank
-      graphComplete.foreach { n => pagerank(n.id) shouldEqual 0.1 }
+      graphComplete.foreach { n => pagerank(n.id) should be (0.1 +- 1E-8) }
+    }
+
+    "Handle dangling nodes correctly when graph is stored only out" in {
+      val target = Array(0.0, 0.11622, 0.21500, 0.16763, 0.16763, 0.07625, 0.14106, 0.11622)
+      testGraphHelper(TestGraphs.dangling_g7, target)
+    }
+
+    "Handle dangling nodes correctly when graph is stored only in" in {
+      val target = Array(0.0, 0.12085, 0.15194, 0.05628, 0.05628, 0.28697, 0.27141, 0.05628)
+      testGraphHelper(TestGraphs.dangling_g7_in, target)
+    }
+
+    "Handle small graphs with dangling nodes" in {
+      val target = Array(0.1844167814, 0.3411710471, 0.4744121714)
+      testGraphHelper(TestGraphs.g3_dangling_out, target, tolerance=5E-10)
+      testGraphHelper(TestGraphs.g3_dangling_in, target.reverse, tolerance=5E-10)
     }
   }
 }


### PR DESCRIPTION
Apparently we did not handle dangling nodes at all in the implementation of page rank.  This new implementation taken from [here] (https://github.com/networkx/networkx/blob/master/networkx/algorithms/link_analysis/pagerank_alg.py) correctly handles dangling nodes.

This PR directly addresses #186 

cc @pankajgupta 
cc @alexloginov