### PR TITLE
fixed copy-paste error: use graph with LongIds instead of StringIds

### DIFF
--- a/cassovary-core/src/test/scala/com/twitter/cassovary/util/io/ListOfEdgesGraphReaderSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/util/io/ListOfEdgesGraphReaderSpec.scala
@@ -94,7 +94,7 @@ class ListOfEdgesGraphReaderSpec extends WordSpec with GraphBehaviours[Node] wit
     }
     "using Long ids" should {
       "provide the correct graph properties" in {
-        new GraphWithStringIds {
+        new GraphWithLongIds {
           graph.nodeCount should be(6)
           graph.edgeCount should be(6L)
           graph.maxNodeId should be(5)


### PR DESCRIPTION
I found it when working on issue #185 