### PR TITLE
[bug fix] Jaccard Similarity returns zero when union is empty.

### DIFF
--- a/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/similarity/JaccardSimilarity.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/algorithms/similarity/JaccardSimilarity.scala
@@ -29,7 +29,7 @@ class JaccardSimilarity(val graph: DirectedGraph[Node]) extends Similarity {
     val neighborsOfV = getNeighbors(v, dir).get
     val commonNeighbors = neighborsOfU intersect neighborsOfV
     val unionNeighbors = neighborsOfU union neighborsOfV
-    if (unionNeighbors.isEmpty) 0
+    if (unionNeighbors.isEmpty) 1
     else commonNeighbors.size.toDouble / unionNeighbors.size
   }
 


### PR DESCRIPTION
Jaccard Similarity score should be one when union is empty.
Wiki link - https://en.wikipedia.org/wiki/Jaccard_index
