### PR TITLE
Implement efficient dynamic graph for the case of concurrent reads an…

### DIFF
--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/DynamicDirectedGraphHashMap.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/DynamicDirectedGraphHashMap.scala
@@ -46,17 +46,18 @@ abstract class DynamicDirectedGraphHashMap(val storedGraphDir: StoredGraphDir)
    * Get the total number of edges in the graph. It's a very slow function. Use it carefully.
    */
   def edgeCount = iterator.foldLeft(0) {(accum, node) =>
-    accum + node.inboundCount  + node.outboundCount
+    accum + (storedGraphDir match {
+      case OnlyOut | BothInOut => node.outboundCount
+      case OnlyIn => node.inboundCount
+      case Mutual => 2 * node.outboundCount // count each edge twice
+    })
   }
 
   /**
    * Get a node given a nodeId {@code id}. Returns None if the id is in in the graph.
    */
-  def getNodeById(id: Int): Option[DynamicNode] = {
-    val n = nodes.get(id)
-    if (n == null) None
-    else Some(n)
-  }
+  def getNodeById(id: Int): Option[DynamicNode] =
+    Option(nodes.get(id))
 
   /**
    * Get or create a node given a nodeId {@code id} and return it.
@@ -82,7 +83,7 @@ abstract class DynamicDirectedGraphHashMap(val storedGraphDir: StoredGraphDir)
    * Don't support this operator. It always throws exceptions.
    */
   override lazy val maxNodeId = {
-    throw new Exception("DynamicGraph doesn't support maxNodeId")
+    throw new UnsupportedOperationException("DynamicGraph doesn't support maxNodeId")
   }
 
   def addEdge(srcId: Int, destId: Int) {

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/SemiSynchronizedDynamicGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/SemiSynchronizedDynamicGraph.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2014 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.twitter.cassovary.graph
+
+import com.twitter.cassovary.graph.StoredGraphDir._
+import com.twitter.cassovary.graph.node.DynamicNode
+
+/**
+ * An efficient dynamic graph implementation which supports concurrent reading and writing, as long as only a single
+ * thread is writing at a time.  This restriction allows it to avoid the use of locks or synchronized sections of code
+ * apart from the locking the occurs when nodes are added to a ConcurrentHashMap.
+ * Nodes are stored in a ConcurrentHashMap, and neighbors of each node are stored in Array[Int]s.  Currently, only edge
+ * and node addition (not deletion) is supported.
+ */
+class SemiSynchronizedDynamicGraph()
+    extends DynamicDirectedGraphHashMap(BothInOut) {
+  override def nodeFactory(id: Int): DynamicNode = new SemiSynchronizedNode(id)
+}
+
+private class SemiSynchronizedNode(val id: Int) extends DynamicNode {
+  val outboundList = new SemiSynchronizedIntArrayList()
+  val inboundList = new SemiSynchronizedIntArrayList()
+
+  override def outboundNodes(): Seq[Int] = outboundList.toSeq
+  override def inboundNodes(): Seq[Int] = inboundList.toSeq
+  /**
+   * Add outbound edges {@code nodeId} into the outbound list
+   */
+  override def addOutBoundNodes(nodeIds: Seq[Int]): Unit =
+    outboundList.append(nodeIds)
+
+  /**
+   * Add inbound edges {@code nodeIds} into the inbound list.
+   */
+  override def addInBoundNodes(nodeIds: Seq[Int]): Unit =
+    inboundList.append(nodeIds)
+
+  override def removeInBoundNode(nodeId: Int): Unit = throw new UnsupportedOperationException()
+  override def removeOutBoundNode(nodeId: Int): Unit = throw new UnsupportedOperationException()
+}
+
+/** A resizable array of Ints with limited functionality.  It supports concurrent reading and writing as long as only
+  * one thread writes at a time.  The only mutable operation supported is appending Ints (not changing or removing current Ints).
+  */
+// We store Ints in an array padded with extra capacity that will grow over time
+// We essentially want a fastutil IntArrayList, but to get volatile references we will manage the array resizing
+// explicitly.
+private class SemiSynchronizedIntArrayList {
+  @volatile private var intArray: Array[Int] = new Array[Int](SemiSynchronizedIntArrayList.initialCapacity)
+  @volatile private var size = 0
+
+  def append(ints: Seq[Int]): Unit = {
+    if (size + ints.size > intArray.length) {
+      val newCapacity = math.max(
+        (intArray.length * SemiSynchronizedIntArrayList.resizeFactor).toInt,
+        size + ints.size)
+      val newIntArray = new Array[Int](newCapacity)
+      System.arraycopy(intArray, 0, newIntArray, 0, size)
+      intArray = newIntArray
+    }
+    // Update outgoingArray before updating size, so concurrent reader threads don't read past the end of the array
+    for (i <- 0 until ints.size) {
+      intArray(i + size) = ints(i)
+    }
+    size = size + ints.size
+  }
+
+  /** Returns an immutable view of the current Ints in this object.
+   */
+  def toSeq: IndexedSeq[Int] = new IntArrayView(size, intArray)
+}
+
+object SemiSynchronizedIntArrayList {
+  val initialCapacity = 2
+  val resizeFactor = 2.0
+}
+
+/**
+ * Stores a reference to an array and a size.  The view is immutable assuming the first size entries of the array don't change.
+ */
+class IntArrayView(override val size: Int, private val intArray: Array[Int]) extends IndexedSeq[Int] {
+  override def length: Int = size
+  override def apply(idx: Int): Int = intArray(idx)
+}

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/SemiSynchronizedDynamicGraphSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/SemiSynchronizedDynamicGraphSpec.scala
@@ -1,0 +1,48 @@
+package com.twitter.cassovary.graph
+
+
+import org.scalatest.{Matchers, WordSpec}
+
+class SemiSynchronizedDynamicGraphSpec extends WordSpec with Matchers {
+  "A SemiSynchronizedDynamicDirectedGraphSpec" should {
+    "support adding nodes" in {
+      val graph = new SemiSynchronizedDynamicGraph()
+      for (i <- 0 until 3) {
+        graph.nodeCount shouldEqual i
+        graph.edgeCount shouldEqual 0
+        graph.getOrCreateNode(10 * i) // non-contiguous
+      }
+      graph.getOrCreateNode(10) // Accessing again should increase node count
+      graph.nodeCount shouldEqual 3
+      graph.existsNodeId(1000000) shouldEqual false
+    }
+
+    "support adding edges" in {
+      val graph = new SemiSynchronizedDynamicGraph()
+      graph.addEdge(1, 2)
+      // For now, addEdge allows duplicates.  graph.addEdge(1, 2) // Test duplicate elimination
+      graph.edgeCount shouldEqual 1
+      val node1 = graph.getNodeById(1).get
+      node1.inboundNodes.toList shouldEqual ( List())
+      node1.outboundNodes.toList shouldEqual (List(2))
+      val node2 = graph.getNodeById(2).get
+      node2.inboundNodes.toList shouldEqual (List(1))
+      node2.outboundNodes.toList shouldEqual (List())
+
+      // test immutability of outboundNodes
+      val oldOutboundNodes1: Seq[Int] = node1.outboundNodes()
+      val oldInboundNodes2: Seq[Int] = node2.inboundNodes()
+      graph.addEdge(1, 10)
+      graph.addEdge(200, 2)
+      oldOutboundNodes1.toList shouldEqual (List(2))
+      oldInboundNodes2.toList shouldEqual (List(1))
+
+      // Test multi-edge
+      graph.addEdge(1, 2)
+      node1.inboundNodes.toList shouldEqual (List())
+      node1.outboundNodes.toList shouldEqual (List(2, 10, 2))
+      node2.inboundNodes.toList shouldEqual (List(1, 200, 1))
+      node2.outboundNodes.toList shouldEqual (List())
+    }
+  }
+}


### PR DESCRIPTION
…d single-threaded writes.
@ashishgpersonal When you have time, could you code review this?
Also, two questions:
1. Currently addEdges does not check for duplicate edges, because e.g. if Obama gets a new in-neighbor I don't want to scan all his current in-neighbors, and I don't want the overhead of using hashMaps rather than arrays.  I think duplicate edges should be rare enough for us to ignore for now--is that OK?  It's not hard to add the check, it's just an efficiency question.
2. I don't think it's easy to test race conditions without inserting artificial `Thread.sleep` calls.  Could you look carefully at the `append` method in `SemiSynchronizedIntArrayList` and see if you think it's thread safe with concurrent readers?

Thanks