### PR TITLE
Memory mapped graph

### DIFF
--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraph.scala
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.twitter.cassovary.graph
+
+import com.twitter.cassovary.util.io.{IntLongSource, MemoryMappedIntLongSource}
+import java.io._
+
+/**
+ * A graph which reads edge data from a memory mapped file.  There is no object overhead per
+ * node: the memory used for n nodes and m edges with both in-neighbor and out-neighbor access is
+ * exactly 16 + 16*n + 8*m bytes. Also, loading is very fast because no parsing of text is required.
+ * Loading time is exactly the time it takes the operating system to map data from disk into
+ * memory.  Nodes are numbered sequentially from 0 to nodeCount - 1 and must be a range of this
+ * form (i.e. nodeCount == maxNodeId + 1).
+ *
+ * When transforming a graph where nodeCount <= maxNodeId
+ * to this format, new nodes with no neighbors will be implicitly created.  Currently only supports
+ * storing both in-neighbors and out-neighbors of nodes (StoredGraphDir.BothInOut). The binary
+ * format is currently subject to change.  Node objects are created on demand when getNodeById is
+ * called.
+ */
+
+/* Storage format
+byteCount  data
+8          (reserved, later use for versioning or indicating undirected vs directed)
+8          n (i. e. the number of nodes).  Currently must be less than 2^31.
+8*(n+1)    Offsets into out-neighbor data. Index i (a Long) points to the out-neighbor data of
+           node i.  The out-neighbor data must be stored in sequential order by id, as the
+           outegree of node i is computed from the difference in offset between node i+1 and node i.
+           Index n is needed to compute the outdegree of node n - 1.
+8*(n+1)    Offsets into in-neighbor data (Longs) (Same interpretation as out-neighbor offsets)
+m          out-neighbor data
+m          in-neighbor data
+ */
+class MemoryMappedDirectedGraph(file: File) extends DirectedGraph[Node] {
+  val data: IntLongSource = new MemoryMappedIntLongSource(file)
+
+  val nodeCount = data.getLong(8).toInt // In the future we may want to support Long ids, so
+  // store nodeCount as Long
+
+  private def outboundOffset(id: Int): Long = data.getLong(16L + 8L * id)
+
+  private def outDegree(id: Int): Int = ((outboundOffset(id + 1) - outboundOffset(id)) / 4).toInt
+
+  private def inboundOffset(id: Int): Long = data.getLong(16L + 8L * (nodeCount + 1) + 8L * id)
+
+  private def inDegree(id: Int): Int = ((inboundOffset(id + 1) - inboundOffset(id)) / 4).toInt
+
+  /* Only created when needed (there is no array of these stored). */
+  private class MemoryMappedDirectedNode(override val id: Int) extends Node {
+    val nodeOutboundOffset = outboundOffset(id)
+    val nodeInboundOffset = inboundOffset(id)
+    def outboundNodes(): Seq[Int] = new IndexedSeq[Int] {
+      val length: Int = outDegree(id)
+      def apply(i: Int): Int =  data.getInt(nodeOutboundOffset + 4L * i)
+    }
+    def inboundNodes(): Seq[Int] = new IndexedSeq[Int] {
+      val length: Int = inDegree(id)
+      def apply(i: Int): Int =  data.getInt(nodeInboundOffset + 4L * i)
+    }
+  }
+
+  def getNodeById(id: Int): Option[Node] =
+    if(0 <= id && id < nodeCount) {
+      Some(new MemoryMappedDirectedNode(id))
+    } else {
+      None
+    }
+
+  def iterator: Iterator[Node] = (0 to nodeCount).iterator flatMap (i => getNodeById(i))
+
+  lazy val edgeCount: Long = outboundOffset(nodeCount) - outboundOffset(0)
+
+  override lazy val maxNodeId = nodeCount - 1
+
+  val storedGraphDir = StoredGraphDir.BothInOut
+}
+
+object MemoryMappedDirectedGraph {
+  /** Writes the given graph to the given file (overwriting it if it exists) in the current binary
+   * format.
+   */
+  def graphToFile(graph: DirectedGraph[Node], file: File): Unit = {
+    val n = graph.maxNodeId + 1 // includes both 0 and maxNodeId as ids
+    val out = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(file)))
+    out.writeLong(0)
+    out.writeLong(n)
+    //The outneighbor data starts after the initial 8 bytes, n+1 Longs for outneighbors, and n+1
+    // Longs for in-neighbors
+    var outboundOffset = 16L + 8L * (n + 1) * 2
+    for (i <- 0 until n) {
+      out.writeLong(outboundOffset)
+      outboundOffset += 4 * (graph.getNodeById(i) map (_.outboundCount)).getOrElse(0)
+    }
+    out.writeLong(outboundOffset) // Needed to compute outdegree of node n-1
+
+    // The inbound data starts immediately after the outbound data
+    var inboundOffset = outboundOffset
+    for (i <- 0 until n) {
+      out.writeLong(inboundOffset)
+      inboundOffset += 4 * (graph.getNodeById(i) map (_.inboundCount)).getOrElse(0)
+    }
+    out.writeLong(inboundOffset) // Needed to compute indegree of node n-1
+
+    for (i <- 0 until n) {
+      for (v <- (graph.getNodeById(i) map (_.outboundNodes())).getOrElse(Nil)) {
+        out.writeInt(v)
+      }
+    }
+    for (i <- 0 until n) {
+      for (v <- (graph.getNodeById(i) map (_.inboundNodes())).getOrElse(Nil)) {
+        out.writeInt(v)
+      }
+    }
+    out.close()
+  }
+}

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/util/io/MemoryMappedIntLongSource.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/util/io/MemoryMappedIntLongSource.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 Teapot, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.twitter.cassovary.util.io
+
+import java.io.File
+import java.nio.channels.FileChannel
+import java.nio.channels.FileChannel.MapMode
+import java.nio.file.StandardOpenOption
+import java.nio.MappedByteBuffer
+
+/**
+ * Represents an arbitrarily large sequence of bytes which can be interpreted as ints or longs.
+ */
+trait IntLongSource {
+  /** Returns the int at the given byte index, which must be a multiple of 4. */
+  def getInt(index: Long): Int
+  /** Returns the Long at the given byte index, which must be a multiple of 8. */
+  def getLong(index: Long): Long
+}
+
+/**
+ * Wraps a sequence of FileChannels to enable random access on a memory mapped file of arbitrary size.
+ * Motivation: FileChannel.open only supports 2GB at a time.
+ * @param file The file containing binary data.
+ */
+
+class MemoryMappedIntLongSource(file: File) extends IntLongSource {
+  def this(fileName: String) = this(new File(fileName))
+
+  private val fileChannel = FileChannel.open(file.toPath, StandardOpenOption.READ)
+
+  // Each buffer uses int addressing, so can only access 2GB.  We'll use multiple buffers,
+  // and access 2^30 bytes per buffer.
+  // We use 2^30 bytes per buffer rather than 2^31 because fileChannel.map doesn't currently
+  // support size 2^31.
+  private val bytesPerBuffer = 1L << 30
+  // ceiling of file.length() / bytesPerBuffer
+  private val bufferCount = ((file.length() + bytesPerBuffer - 1) / bytesPerBuffer).toInt
+  private val byteBuffers: Array[MappedByteBuffer] = (0 until bufferCount).toArray map { bufferIndex =>
+    val size = if (bufferIndex + 1 < bufferCount)
+      bytesPerBuffer
+    else
+      file.length - (bufferCount - 1L) * bytesPerBuffer
+    fileChannel.map(MapMode.READ_ONLY, bufferIndex * bytesPerBuffer, size)
+  }
+  private def bufferIndex(index: Long): Int = (index >> 30).toInt
+  private def indexWithinBuffer(index: Long): Int = (index & 0x3FFFFFFF).toInt
+
+  def getInt(index: Long): Int = byteBuffers(bufferIndex(index)).getInt(indexWithinBuffer(index))
+
+  def getLong(index: Long): Long = byteBuffers(bufferIndex(index)).getLong(indexWithinBuffer(index))
+}

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraphSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraphSpec.scala
@@ -1,0 +1,39 @@
+package com.twitter.cassovary.graph
+
+import java.io.File
+import java.nio.file.NoSuchFileException
+
+import org.scalatest.{Matchers, WordSpec}
+
+class MemoryMappedDirectedGraphSpec extends WordSpec with Matchers {
+  val testGraph1 = ArrayBasedDirectedGraph.apply(
+    Iterable(
+      NodeIdEdgesMaxId(1, Array(2, 3)),
+      NodeIdEdgesMaxId(3, Array(1, 2)),
+      NodeIdEdgesMaxId(5, Array(1))
+    ),
+    StoredGraphDir.BothInOut,
+    NeighborsSortingStrategy.LeaveUnsorted)
+
+  "A MemoryMappedDirectedGraph" should {
+    "correctly store and read a graph" in {
+      val tempFile = File.createTempFile("graph1", ".bin")
+      MemoryMappedDirectedGraph.graphToFile(testGraph1, tempFile)
+      val graph1 = new MemoryMappedDirectedGraph(tempFile)
+      for (testNode <- testGraph1) {
+        val node = graph1.getNodeById(testNode.id).get
+        node.outboundNodes should contain theSameElementsAs (testNode.outboundNodes)
+        node.inboundNodes should contain theSameElementsAs (testNode.inboundNodes)
+      }
+      graph1.getNodeById(-1) should be(None)
+      graph1.getNodeById(6) should be(None)
+      graph1.getNodeById(1 << 29) should be(None)
+    }
+
+    "throw an error given an invalid filename" in {
+      a[NoSuchFileException] should be thrownBy {
+        new MemoryMappedDirectedGraph(new File("nonexistant_file_4398219812437401"))
+      }
+    }
+  }
+}

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/util/io/MemoryMappedIntLongSourceSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/util/io/MemoryMappedIntLongSourceSpec.scala
@@ -1,0 +1,61 @@
+package com.twitter.cassovary.util.io
+
+import java.io.{File, RandomAccessFile}
+import java.nio.file.NoSuchFileException
+
+import org.scalatest.{Matchers, WordSpec}
+
+class MemoryMappedIntLongSourceSpec extends WordSpec with Matchers {
+  "MemoryMappedIntLongSource" should {
+    "read Ints and Longs from a multi-GB file" in {
+       // create a file with ints and long at various locations
+       val intValues = Map(
+         0L -> 12,
+         4L -> -34,
+         // Make sure ints on both sides of a buffer boundary are read correctly
+         (1L << 30) - 4 -> 56,
+         (1L << 30) -> 12345678
+       )
+      val longValues = Map(
+        (1L << 32) - 8 -> 98L,
+        (1L << 32) -> -76L,
+        (1L << 32) + 128 -> 123456789012345L
+      )
+      val file = File.createTempFile("IntLongData", "dat")
+      val out = new RandomAccessFile(file, "rw")
+      for ((i, value) <- intValues) {
+        out.seek(i)
+        out.writeInt(value)
+      }
+      for ((i, value) <- longValues) {
+        out.seek(i)
+        out.writeLong(value)
+      }
+      out.close()
+
+      // Verify that the source can read the written data
+      val source = new MemoryMappedIntLongSource(file)
+      for ((i, value) <- intValues) {
+        source.getInt(i) shouldEqual (value)
+      }
+      for ((i, value) <- longValues) {
+        source.getLong(i) shouldEqual (value)
+      }
+
+      an[ArrayIndexOutOfBoundsException] should be thrownBy {
+        source.getInt(1L << 33)
+      }
+      an[IndexOutOfBoundsException] should be thrownBy {
+        source.getLong((1L << 32) + 129L)
+      }
+
+      file.deleteOnExit()
+    }
+
+    " throw an error given an invalid filename" in {
+      a[NoSuchFileException] should be thrownBy {
+        new MemoryMappedIntLongSource("nonexistant_file_4398219812437401")
+      }
+    }
+  }
+}

--- a/cassovary-examples/src/main/scala/MemoryMappedDirectedGraphExample.scala
+++ b/cassovary-examples/src/main/scala/MemoryMappedDirectedGraphExample.scala
@@ -1,0 +1,53 @@
+import java.io.File
+
+import com.twitter.cassovary.graph.StoredGraphDir._
+import com.twitter.cassovary.graph.{MemoryMappedDirectedGraph, StoredGraphDir, Node, DirectedGraph}
+import com.twitter.cassovary.util.NodeNumberer
+import com.twitter.cassovary.util.io.AdjacencyListGraphReader
+
+/**
+ * Demonstrates conversion of a graph from adjacency list format to MemoryMappedDirectedGraph
+ * binary format.
+ */
+object MemoryMappedDirectedGraphExample {
+  def readGraph(graphPath: String): DirectedGraph[Node] = {
+    val filenameStart = graphPath.lastIndexOf('/') + 1
+    val graphDirectory = graphPath.take(filenameStart)
+    val graphFilename = graphPath.drop(filenameStart)
+    println("loading graph:" + graphFilename)
+
+    val reader = new AdjacencyListGraphReader(
+      graphDirectory,
+      graphFilename,
+      new NodeNumberer.IntIdentity(),
+      _.toInt) {
+      override def storedGraphDir: StoredGraphDir = StoredGraphDir.BothInOut
+    }
+    reader.toArrayBasedDirectedGraph()
+  }
+
+  def main(args: Array[String]): Unit = {
+    var startTime = System.currentTimeMillis()
+    val testNodeId = 30000000
+    val graphName = args(1)
+    if (args(0) == "readAdj") {
+      val graph = readGraph(graphName)
+      println(s"outneighbors of node $testNodeId: " +
+        graph.getNodeById(testNodeId).get.outboundNodes())
+      val loadTime = (System.currentTimeMillis() - startTime) / 1000.0
+      println(s"Time to read adj graph: $loadTime")
+
+      val binaryFileName = graphName.substring(0, graphName.lastIndexOf(".")) + ".dat"
+      startTime = System.currentTimeMillis()
+      MemoryMappedDirectedGraph.graphToFile(graph, new File( binaryFileName))
+      val writeTime = (System.currentTimeMillis() - startTime) / 1000.0
+      println(s"Time to write binary graph: $writeTime")
+    } else if (args(0) == "readBin") {
+      val graph = new MemoryMappedDirectedGraph(new File(graphName))
+      println(s"outneighbors of node $testNodeId: " +
+        graph.getNodeById(testNodeId).get.outboundNodes())
+      val loadTime = (System.currentTimeMillis() - startTime) / 1000.0
+      println(s"Time to read binary graph: $loadTime")
+    }
+  }
+}


### PR DESCRIPTION
This is a graph that stores its data in a memory mapped file. This enables two nice features:
1) No object overhead.  The memory used for n nodes and m edges with both in-neighbor and out-neighbor access is exactly 8 + 16*n + 8*m bytes
2) Nearly instant graph loading.  The twitter-2010 graph with 1.5 billion edges loads in seconds if the binary graph file is already in OS cache, and otherwise loads in the time it takes the OS to transfer the file from disk to RAM.

@pankajgupta 