### PR TITLE
Giving access to the depth information for all nodes.

### DIFF
--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/Traverser.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/Traverser.scala
@@ -410,6 +410,7 @@ trait DepthTracker extends QueueBasedTraverser[Node] {
   }
 
   def depth(id: Int) = depthTracker.infoOfNode(id)
+  def depthAllNodes = depthTracker.infoAllNodes
 }
 
 /**


### PR DESCRIPTION
Making InfoKeepers' infoAllNodes accessible through depth tracker's method.