### PR TITLE
Passing max id being max of node id and edges ids to NodeIdEdgesMaxId.

### DIFF
--- a/cassovary-core/src/main/scala/com/twitter/cassovary/util/io/ListOfEdgesGraphReader.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/util/io/ListOfEdgesGraphReader.scala
@@ -190,8 +190,8 @@ class ListOfEdgesGraphReader[T](
         val buf = idAndEdgesIterator.next()
         val id = buf(0)
         val edgesArr = buf.toArray(1)
-        val (edges, maxId) = prepareEdges(edgesArr)
-        val nodeMaxId = id.max(maxId)
+        val (edges, edgesMaxId) = prepareEdges(edgesArr)
+        val nodeMaxId = id.max(edgesMaxId)
         NodeIdEdgesMaxId(id, edges, nodeMaxId)
       }
     }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/util/io/ListOfEdgesGraphReader.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/util/io/ListOfEdgesGraphReader.scala
@@ -191,7 +191,8 @@ class ListOfEdgesGraphReader[T](
         val id = buf(0)
         val edgesArr = buf.toArray(1)
         val (edges, maxId) = prepareEdges(edgesArr)
-        NodeIdEdgesMaxId(id, edges, maxId)
+        val nodeMaxId = id.max(maxId)
+        NodeIdEdgesMaxId(id, edges, nodeMaxId)
       }
     }
   }


### PR DESCRIPTION
Hey guys,
This PR is more a question than full solution for what I believe is a bug in the `ListOfEdgesGraphReader`. Let me know if my understanding is correct.

Below is the scenario where I spotted this issue, and that should allow you to reproduce it:
1. I tried to load `http://snap.stanford.edu/data/email-EuAll.txt.gz` using ListOfEdgesGraphReader and called `.toArrayBasedDirectedGraph` or `.toSharedArrayBasedDirectedGraph` on it. 
2. It threw 
```
 java.lang.ArrayIndexOutOfBoundsException: 265193
 	at com.twitter.cassovary.util.ArrayBackedSet.add(ArrayBackedSet.scala:16)
 	at com.twitter.cassovary.graph.ArrayBasedDirectedGraph$ArrayBasedDirectedGraphConstructor$$anonfun$com$twitter$cassovary$graph$ArrayBasedDirectedGraph$ArrayBasedDirectedGraphConstructor$$markEmptyNodes$1$$anonfun$apply$19$$anonfun$apply$2$$anonfun$apply$mcV$sp$1.apply(ArrayBasedDirectedGraph.scala:233)
 	at com.twitter.cassovary.graph
 (...)
```
3. In `ArrayBasedDirectedGraph.scala:233` we use `allNodeIdsSet` instantiated with `graphInfo.maxNodeId` as the array size. `graphInfo.maxNodeId` comes from line `188` of this file and equals `maxNodeIdAll max maxIdInPart`.  
4. I noticed that in `ListOfEdgesGraphReader.scala` the constructor of `NodeIdEdgesMaxId` takes `maxId` directly from the reader, which causes it's inconsistent behaviour with the `NodeIdEdgesMaxId` being constructed using only `id` and `edges` params. In the latter case `maxId` would equal `max(id, edges)` not `max(edges)` as in the former.