### PR TITLE
Use https instead of http in urls

### DIFF
--- a/cassovary-benchmarks/src/main/scala/com/twitter/cassovary/PerformanceBenchmark.scala
+++ b/cassovary-benchmarks/src/main/scala/com/twitter/cassovary/PerformanceBenchmark.scala
@@ -82,7 +82,7 @@ object PerformanceBenchmark extends GzipGraphDownloader {
   val separatorInt = flags("separator", defaultSeparatorEdges,
     "Separator between source and destination ids in decimal value of the character")
   val remoteFileFlag = flags("url",
-    "http://snap.stanford.edu/data/cit-HepTh.txt.gz",
+    "https://snap.stanford.edu/data/cit-HepTh.txt.gz",
     "Specify a URL to download a graph file from")
   val helpFlag = flags("h", false, "Print usage")
   val globalPRFlag = flags("globalpr", false, "run global pagerank benchmark")

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -35,7 +35,7 @@ object Cassovary extends Build {
       "com.twitter" %% "finagle-stats" % finagleVersion,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value
     ),
-    resolvers += "twitter repo" at "http://maven.twttr.com",
+    resolvers += "twitter repo" at "https://maven.twttr.com",
 
     scalacOptions ++= Seq("-encoding", "utf8"),
     scalacOptions += "-deprecation",
@@ -49,7 +49,7 @@ object Cassovary extends Build {
     pomIncludeRepository := { _ => false },
     publishMavenStyle := true,
     pomExtra := (
-      <url>http://twitter.com/cassovary</url>
+      <url>https://twitter.com/cassovary</url>
       <licenses>
         <license>
           <name>Apache 2</name>

--- a/sbt
+++ b/sbt
@@ -10,7 +10,7 @@ sbtver=0.13.9
 rawsbtjar=sbt-launch.jar
 sbtdir=$HOME/.sbt/launchers/$sbtver
 sbtjar=$sbtdir/$rawsbtjar
-SBTURL=http://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$sbtver/$rawsbtjar
+SBTURL=https://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$sbtver/$rawsbtjar
 JARMD5=767d963ed266459aa8bf32184599786d
 
 if [ ! -f $sbtjar ]; then


### PR DESCRIPTION
This PR changes every instance of an http url to its https version for security reasons.